### PR TITLE
Fix #35 - test typo inconsistencies

### DIFF
--- a/tests/attributes.js
+++ b/tests/attributes.js
@@ -160,7 +160,7 @@ export default function attributes(Graph, checkers) {
         assert.deepEqual(graph.getEdgeAttributes('John', 'Thomas'), {weight: 2});
       },
 
-      'it should return undefined if the edge does not have attributes.': function() {
+      'it should return an empty object if the edge does not have attributes.': function() {
         const graph = new Graph();
         graph.addNodesFrom(['John', 'Thomas']);
         const edge = graph.addEdge('John', 'Thomas');

--- a/tests/instantiation.js
+++ b/tests/instantiation.js
@@ -22,7 +22,7 @@ const OPTIONS = [
   {multi: true, type: 'undirected'}
 ];
 
-export default function instantiation(Graph, inmplementation, checkers) {
+export default function instantiation(Graph, implementation, checkers) {
   const {
     invalid
   } = checkers;
@@ -30,7 +30,7 @@ export default function instantiation(Graph, inmplementation, checkers) {
   return {
     'Hydratation': {
 
-      'it should be possible to hydrate from a serialized graph.': function() {
+      'it should be possible to hydrate from a Graph instance.': function() {
         const graph = new Graph();
         graph.addNodesFrom(['John', 'Thomas']);
         graph.addEdge('John', 'Thomas');
@@ -41,7 +41,7 @@ export default function instantiation(Graph, inmplementation, checkers) {
         assert.deepEqual(graph.edges(), other.edges());
       },
 
-      'it should be possible to hydrate from a Graph instance.': function() {
+      'it should be possible to hydrate from a serialized graph': function() {
         const graph = new Graph({
           nodes: [
             {key: 'John'},
@@ -182,12 +182,12 @@ export default function instantiation(Graph, inmplementation, checkers) {
     'Constructors': {
 
       'all alternative constructors should be available.': function() {
-        CONSTRUCTORS.forEach(name => assert(name in inmplementation));
+        CONSTRUCTORS.forEach(name => assert(name in implementation));
       },
 
       'alternative constructors should have the correct options.': function() {
         CONSTRUCTORS.forEach((name, index) => {
-          const graph = new inmplementation[name]();
+          const graph = new implementation[name]();
 
           const {
             multi,

--- a/tests/serialization.js
+++ b/tests/serialization.js
@@ -481,7 +481,7 @@ export default function serialization(Graph, checkers) {
         assert.strictEqual(copy.size, 0);
 
         PROPERTIES.forEach(property => {
-          assert.strictEqual(graph[property], graph[property]);
+          assert.strictEqual(graph[property], copy[property]);
         });
       }
     },


### PR DESCRIPTION
See #35 

- Title and compares values properly equal in [**attributes.js**](https://github.com/graphology/graphology/blob/master/tests/attributes.js#L163-L168)
- Copy properly compared in [**serialization.js**](https://github.com/graphology/graphology/blob/master/tests/serialization.js#L471-L486)
- [Hydration tests](https://github.com/graphology/graphology/blob/master/tests/instantiation.js#L31-L58) properly swapped and `inmplementation` [variable name](https://github.com/graphology/graphology/blob/master/tests/instantiation.js#L185) fixed in **instantiation.js**

And ...
- No lint problem 