### PR TITLE
Bugfix for merging undirected edges

### DIFF
--- a/src/graphology/src/graph.js
+++ b/src/graphology/src/graph.js
@@ -408,12 +408,7 @@ function mergeEdge(
     if (edgeData) {
       // Here, we need to ensure, if the user gave a key, that source & target
       // are coherent
-      if (
-        edgeData.source.key !== source ||
-        edgeData.target.key !== target ||
-        (undirected &&
-          (edgeData.source.key !== target || edgeData.target.key !== source))
-      ) {
+      if (!(edgeData.source.key == source && edgeData.target.key == target || undirected && (edgeData.source.key == target && edgeData.target.key == source))) {
         throw new UsageGraphError(
           `Graph.${name}: inconsistency detected when attempting to merge the "${edge}" edge with "${source}" source & "${target}" target vs. ("${edgeData.source.key}", "${edgeData.target.key}").`
         );

--- a/src/graphology/src/graph.js
+++ b/src/graphology/src/graph.js
@@ -408,12 +408,19 @@ function mergeEdge(
     if (edgeData) {
       // Here, we need to ensure, if the user gave a key, that source & target
       // are coherent
-      if (!(edgeData.source.key == source && edgeData.target.key == target || undirected && (edgeData.source.key == target && edgeData.target.key == source))) {
-        throw new UsageGraphError(
-          `Graph.${name}: inconsistency detected when attempting to merge the "${edge}" edge with "${source}" source & "${target}" target vs. ("${edgeData.source.key}", "${edgeData.target.key}").`
-        );
+      if (edgeData.source.key !== source || edgeData.target.key !== target) {
+        // if source or target inconsistent
+        if (
+          !undirected ||
+          edgeData.source.key !== target ||
+          edgeData.target.key !== source
+        ) {
+          // if directed, or source/target aren't flipped
+          throw new UsageGraphError(
+            `Graph.${name}: inconsistency detected when attempting to merge the "${edge}" edge with "${source}" source & "${target}" target vs. ("${edgeData.source.key}", "${edgeData.target.key}").`
+          );
+        }
       }
-
       alreadyExistingEdgeData = edgeData;
     }
   }

--- a/src/graphology/tests/mutation.js
+++ b/src/graphology/tests/mutation.js
@@ -388,10 +388,9 @@ export default function mutation(Graph, checkers) {
         }, usage());
       },
 
-       'it should be able to add undirected edges': function () {
+       'it should be able to merge undirected edges in both directions': function () {
         const graph = new Graph();
         graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
-
         graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
         graph.mergeUndirectedEdgeWithKey('J<->M', 'Martha', 'John');
       },

--- a/src/graphology/tests/mutation.js
+++ b/src/graphology/tests/mutation.js
@@ -388,6 +388,14 @@ export default function mutation(Graph, checkers) {
         }, usage());
       },
 
+       'it should be able to add undirected edges': function () {
+        const graph = new Graph();
+        graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
+
+        graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
+        graph.mergeUndirectedEdgeWithKey('J<->M', 'Martha', 'John');
+      },
+
       'it should distinguish between typed edges.': function () {
         const graph = new Graph();
         graph.mergeEdge('John', 'Martha', {type: 'LIKES'});

--- a/src/graphology/tests/mutation.js
+++ b/src/graphology/tests/mutation.js
@@ -6,7 +6,6 @@
  */
 import assert from 'assert';
 import {addNodesFrom} from './helpers';
-import {UsageGraphError} from '../src/errors';
 
 export default function mutation(Graph, checkers) {
   const {invalid, notFound, usage} = checkers;
@@ -396,7 +395,7 @@ export default function mutation(Graph, checkers) {
             graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
             graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
             graph.mergeUndirectedEdgeWithKey('J<->M', 'Martha', 'John');
-          }, UsageGraphError);
+          }, usage());
         },
 
       'it should distinguish between typed edges.': function () {

--- a/src/graphology/tests/mutation.js
+++ b/src/graphology/tests/mutation.js
@@ -6,6 +6,7 @@
  */
 import assert from 'assert';
 import {addNodesFrom} from './helpers';
+import {UsageGraphError} from '../src/errors';
 
 export default function mutation(Graph, checkers) {
   const {invalid, notFound, usage} = checkers;
@@ -388,12 +389,15 @@ export default function mutation(Graph, checkers) {
         }, usage());
       },
 
-       'it should be able to merge undirected edges in both directions': function () {
-        const graph = new Graph();
-        graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
-        graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
-        graph.mergeUndirectedEdgeWithKey('J<->M', 'Martha', 'John');
-      },
+      'it should be able to merge undirected edges in both directions':
+        function () {
+          assert.doesNotThrow(function () {
+            const graph = new Graph();
+            graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
+            graph.mergeUndirectedEdgeWithKey('J<->M', 'John', 'Martha');
+            graph.mergeUndirectedEdgeWithKey('J<->M', 'Martha', 'John');
+          }, UsageGraphError);
+        },
 
       'it should distinguish between typed edges.': function () {
         const graph = new Graph();


### PR DESCRIPTION
### Description
This is a bug report and suggested fix for .mergeEdge(), along with a unit test for this case.

### Observed Behavior
If .mergeUndirectedEdge() is called with an edge that has the same source and the same target, an error is thrown claiming that there is an inconsistency.

### Expected Behavior
There should be no error, because there is no inconsistency.

### Suggested Solution
I believe I have solved the issue by fixing [the conditional statement](https://github.com/graphology/graphology/blob/a1e6c88d71ccfb0827be59ab1b6272f8487c6b1a/src/graphology/src/graph.js#L411-L416) that determines whether an inconsistency was detected. All unit tests pass, including the new one.
