### PR TITLE
Adds missing edge argument to UpdateEdgeWithKey methods

### DIFF
--- a/src/types/CHANGELOG.md
+++ b/src/types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.24.1
+
+- Adds missing edge argument to UpdateEdgeWithKey methods.
+
 ## 0.24.0
 
 - Improving event emitter types.

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -455,6 +455,7 @@ declare abstract class AbstractGraph<
     attributes?: Partial<EdgeAttributes>
   ): EdgeMergeResult;
   updateEdgeWithKey(
+    edge: unknown,
     source: unknown,
     target: unknown,
     updater?: (attributes: EdgeAttributes | {}) => EdgeAttributes
@@ -472,6 +473,7 @@ declare abstract class AbstractGraph<
     attributes?: Partial<EdgeAttributes>
   ): EdgeMergeResult;
   updateDirectedEdgeWithKey(
+    edge: unknown,
     source: unknown,
     target: unknown,
     updater?: (attributes: EdgeAttributes | {}) => EdgeAttributes
@@ -489,6 +491,7 @@ declare abstract class AbstractGraph<
     attributes?: Partial<EdgeAttributes>
   ): EdgeMergeResult;
   updateUndirectedEdgeWithKey(
+    edge: unknown,
     source: unknown,
     target: unknown,
     updater?: (attributes: EdgeAttributes | {}) => EdgeAttributes

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphology-types",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "TypeScript declaration for graphology.",
   "main": "index.d.ts",
   "files": [


### PR DESCRIPTION
This didn't look right, I checked the code generating the methods for a graph and that confirmed my suspicions.

Hope did this right, thank you for the excellent library.