### PR TITLE
[types] Fix getSourceAttributes input argument

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -568,7 +568,7 @@ declare abstract class AbstractGraph<
     edge: unknown,
     name: AttributeName
   ): NodeAttributes[AttributeName];
-  getSourceAttributes(node: unknown): NodeAttributes;
+  getSourceAttributes(edge: unknown): NodeAttributes;
   hasSourceAttribute<AttributeName extends keyof NodeAttributes>(
     edge: unknown,
     name: AttributeName


### PR DESCRIPTION
The input argument of the `getSourceAttributes` should be named "edge".