### PR TITLE
fix types of updater callback in `#.updateEach*Attributes`

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -681,7 +681,7 @@ declare abstract class AbstractGraph<
   ): this;
 
   updateEachNodeAttributes(
-    updater: NodeMapper<NodeAttributes>,
+    updater: NodeMapper<NodeAttributes, NodeAttributes>,
     hints?: UpdateHints
   ): void;
 
@@ -719,7 +719,7 @@ declare abstract class AbstractGraph<
   ): this;
 
   updateEachEdgeAttributes(
-    updater: EdgeMapper<EdgeAttributes>,
+    updater: EdgeMapper<EdgeAttributes, EdgeAttributes>,
     hints?: UpdateHints
   ): void;
 


### PR DESCRIPTION
This fix adds correct typings to the attributes input in the updater callback of `#.updateEachNodeAttributes` and  `#.updateEachEdgeAttributes`.

**The problem:**  
Currently when using `#.updateEachNodeAttributes` or `#.updateEachEdgeAttributes`, the  attributes input (second parameter) in the updater callback just gets the generic `Attributes` type, not the custom node/edge attributes type specified when creating the graph object. Since the return type of the updater callback is typed to be the custom attributes, one now usually have to cast the attributes input to its correct type.
