### PR TITLE
[layout-forceatlas2] Adds reducer param

### DIFF
--- a/src/layout-forceatlas2/index.d.ts
+++ b/src/layout-forceatlas2/index.d.ts
@@ -22,6 +22,7 @@ export type ForceAtlas2LayoutOptions = {
   iterations: number;
   settings?: ForceAtlas2Settings;
   weighted?: boolean;
+  reducer?: (key: string, attributes: any) => any;
 };
 
 interface IForceAtlas2Layout {

--- a/src/layout-forceatlas2/index.js
+++ b/src/layout-forceatlas2/index.js
@@ -20,6 +20,7 @@ var DEFAULT_SETTINGS = require('./defaults.js');
  * @param  {string}            weight   - Name of the edge weight attribute.
  * @param  {boolean}         weighted   - Whether to take edge weights into account.
  * @param  {number}          iterations - Number of iterations.
+ * @param  {function|null}   reducer    - A node reducer
  * @param  {object}          [settings] - Settings.
  * @return {object|undefined}
  */
@@ -46,6 +47,8 @@ function abstractSynchronousLayout(assign, graph, params) {
   var attributes = params.attributes || {};
   var weightAttribute = params.weighted ? attributes.weight || 'weight' : null;
 
+  var reducer = typeof params.reducer === 'function' ? params.reducer : null;
+
   // Validating settings
   var settings = helpers.assign({}, DEFAULT_SETTINGS, params.settings);
   var validationError = helpers.validateSettings(settings);
@@ -66,7 +69,7 @@ function abstractSynchronousLayout(assign, graph, params) {
 
   // Applying
   if (assign) {
-    helpers.assignLayoutChanges(graph, matrices.nodes);
+    helpers.assignLayoutChanges(graph, matrices.nodes, reducer);
     return;
   }
 

--- a/src/layout-forceatlas2/test.js
+++ b/src/layout-forceatlas2/test.js
@@ -98,6 +98,45 @@ describe('graphology-layout-forceatlas2', function () {
           Ada: {x: 24, y: -1}
         });
       });
+
+      it('should work as expected with a custom reducer.', function () {
+        var graph = new Graph();
+
+        var data = {
+          John: {
+            size: 4,
+            x: 3,
+            y: 4
+          },
+          Martha: {
+            x: 10,
+            y: 5
+          },
+          Ada: {
+            x: 23,
+            y: -2
+          }
+        };
+
+        for (var node in data) graph.addNode(node, data[node]);
+
+        var positions = helpers.collectLayoutChanges(
+          graph,
+          [
+            4, 5, 0, 0, 0, 0, 2, 1, 4, 0, 11, 6, 0, 0, 0, 0, 3, 1, 1, 0, 24, -1,
+            0, 0, 0, 0, 2, 1, 1, 0
+          ],
+          function (node, attributes) {
+            return {...attributes, y: node === 'John' ? 1 : 2};
+          }
+        );
+
+        assert.deepEqual(positions, {
+          John: {x: 4, y: 1},
+          Martha: {x: 11, y: 2},
+          Ada: {x: 24, y: 2}
+        });
+      });
     });
 
     describe('#.assignLayoutChanges', function () {
@@ -140,6 +179,51 @@ describe('graphology-layout-forceatlas2', function () {
           Martha: {x: 11, y: 6},
           Ada: {x: 24, y: -1}
         });
+      });
+
+      it('should work as expected with a custom reducer.', function () {
+        var graph = new Graph();
+
+        var data = {
+          John: {
+            x: 3,
+            y: 4
+          },
+          Martha: {
+            x: 10,
+            y: 5
+          },
+          Ada: {
+            x: 23,
+            y: -2
+          }
+        };
+
+        for (var node in data) graph.addNode(node, data[node]);
+
+        helpers.assignLayoutChanges(
+          graph,
+          [
+            4, 5, 0, 0, 0, 0, 2, 1, 4, 0, 11, 6, 0, 0, 0, 0, 3, 1, 1, 0, 24, -1,
+            0, 0, 0, 0, 2, 1, 1, 0
+          ],
+          function (node, attributes) {
+            return {...attributes, y: node === 'John' ? 1 : 2};
+          }
+        );
+
+        assert.deepEqual(
+          {
+            John: graph.getNodeAttributes('John'),
+            Martha: graph.getNodeAttributes('Martha'),
+            Ada: graph.getNodeAttributes('Ada')
+          },
+          {
+            John: {x: 4, y: 1},
+            Martha: {x: 11, y: 2},
+            Ada: {x: 24, y: 2}
+          }
+        );
       });
     });
   });

--- a/src/layout-forceatlas2/worker.d.ts
+++ b/src/layout-forceatlas2/worker.d.ts
@@ -7,6 +7,7 @@ export type FA2LayoutSupervisorParameters = {
   };
   settings?: ForceAtlas2Settings;
   weighted?: boolean;
+  reducer?: (key: string, attributes: any) => any;
 };
 
 export default class FA2LayoutSupervisor {

--- a/src/layout-forceatlas2/worker.js
+++ b/src/layout-forceatlas2/worker.js
@@ -48,6 +48,7 @@ function FA2LayoutSupervisor(graph, params) {
   this.matrices = null;
   this.running = false;
   this.killed = false;
+  this.reducer = typeof params.reducer === 'function' ? params.reducer : null;
 
   // Binding listeners
   this.handleMessage = this.handleMessage.bind(this);
@@ -103,8 +104,10 @@ FA2LayoutSupervisor.prototype.handleMessage = function (event) {
   if (!this.running) return;
 
   var matrix = new Float32Array(event.data.nodes);
+  var reducer = this.reducer;
 
-  helpers.assignLayoutChanges(this.graph, matrix);
+  helpers.assignLayoutChanges(this.graph, matrix, reducer);
+  if (reducer) helpers.readGraphPositions(this.graph, matrix);
   this.matrices.nodes = matrix;
 
   // Looping


### PR DESCRIPTION
**Warning: This has not been properly tested yet.**

Details:
- Adds `readGraphPositions` to backport graph positions updates to the matrix
- Adds an optional `reducer` argument to `assignLayoutChanges` and `collectLayoutChanges`
- Reads the new `reducer` param in `index` and `worker`, and use it when setting or returning the iteration results
- Adds two unit tests accordingly