### PR TITLE
maxDepth argument for simple paths traversal

### DIFF
--- a/src/simple-path/README.md
+++ b/src/simple-path/README.md
@@ -36,6 +36,9 @@ const paths = allSimplePaths(graph, '1', '3');
 
 // To get cycles, just pass same source & target
 const cycles = allSimplePaths(graph, '1', '1');
+
+// To limit traversal to a certain depth
+const limitedPaths = allSimplePaths(graph, '1', '3', 2);
 ```
 
 _Arguments_
@@ -43,6 +46,7 @@ _Arguments_
 - **graph** _Graph_: target graph.
 - **source** _string_: source node.
 - **target** _string_: target node.
+- **maxDepth** _number_: max traversal depth (default - no limit).
 
 ### allSimpleEdgePaths
 
@@ -66,6 +70,9 @@ const paths = allSimpleEdgePaths(graph, '1', '3');
 
 // To get cycles, just pass same source & target
 const cycles = allSimpleEdgePaths(graph, '1', '1');
+
+// To limit traversal to a certain depth
+const limitedPaths = allSimpleEdgePaths(graph, '1', '3', 2);
 ```
 
 _Arguments_
@@ -73,6 +80,7 @@ _Arguments_
 - **graph** _Graph_: target graph.
 - **source** _string_: source node.
 - **target** _string_: target node.
+- **maxDepth** _number_: max traversal depth (default - no limit).
 
 ### allSimpleEdgeGroupPaths
 
@@ -97,6 +105,9 @@ const paths = allSimpleEdgeGroupPaths(graph, '1', '3');
 
 // To get cycles, just pass same source & target
 const cycles = allSimpleEdgeGroupPaths(graph, '1', '1');
+
+// To limit traversal to a certain depth
+const limitedPaths = allSimpleEdgeGroupPaths(graph, '1', '3', 2);
 ```
 
 _Arguments_
@@ -104,3 +115,4 @@ _Arguments_
 - **graph** _Graph_: target graph.
 - **source** _string_: source node.
 - **target** _string_: target node.
+- **maxDepth** _number_: max traversal depth (default - no limit).

--- a/src/simple-path/index.d.ts
+++ b/src/simple-path/index.d.ts
@@ -3,15 +3,18 @@ import Graph from 'graphology-types';
 export function allSimplePaths(
   graph: Graph,
   source: unknown,
-  target: unknown
+  target: unknown,
+  maxDepth?: number
 ): Array<Array<string>>;
 export function allSimpleEdgePaths(
   graph: Graph,
   source: unknown,
-  target: unknown
+  target: unknown,
+  maxDepth?: number
 ): Array<Array<string>>;
 export function allSimpleEdgeGroupPaths(
   graph: Graph,
   source: unknown,
-  target: unknown
+  target: unknown,
+  maxDepth?: number
 ): Array<Array<Array<string>>>;

--- a/src/simple-path/index.js
+++ b/src/simple-path/index.js
@@ -86,12 +86,13 @@ RecordStackSet.of = function (value) {
 /**
  * Function returning all the paths between source & target in the graph.
  *
- * @param  {Graph}  graph  - Target graph.
- * @param  {string} source - Source node.
- * @param  {string} target - Target node.
- * @return {array}         - The found paths.
+ * @param  {Graph}  graph    - Target graph.
+ * @param  {string} source   - Source node.
+ * @param  {string} target   - Target node.
+ * @param  {number} maxDepth - Max traversal depth (default: no limit).
+ * @return {array}           - The found paths.
  */
-function allSimplePaths(graph, source, target) {
+function allSimplePaths(graph, source, target, maxDepth) {
   if (!isGraph(graph))
     throw new Error(
       'graphology-simple-path.allSimplePaths: expecting a graphology instance.'
@@ -144,7 +145,7 @@ function allSimplePaths(graph, source, target) {
 
       visited.push(child);
 
-      if (!visited.has(target)) stack.push(graph.outboundNeighbors(child));
+      if (!visited.has(target) && (maxDepth === undefined || stack.length < maxDepth)) stack.push(graph.outboundNeighbors(child));
       else visited.pop();
     }
   }
@@ -188,12 +189,13 @@ function collectMultiEdges(graph, source) {
 /**
  * Function returning all the edge paths between source & target in the graph.
  *
- * @param  {Graph}  graph  - Target graph.
- * @param  {string} source - Source node.
- * @param  {string} target - Target node.
- * @return {array}         - The found paths.
+ * @param  {Graph}  graph    - Target graph.
+ * @param  {string} source   - Source node.
+ * @param  {string} target   - Target node.
+ * @param  {number} maxDepth - Max traversal depth (default: no limit).
+ * @return {array}           - The found paths.
  */
-function allSimpleEdgePaths(graph, source, target) {
+function allSimpleEdgePaths(graph, source, target, maxDepth) {
   if (!isGraph(graph))
     throw new Error(
       'graphology-simple-path.allSimpleEdgePaths: expecting a graphology instance.'
@@ -250,7 +252,7 @@ function allSimpleEdgePaths(graph, source, target) {
 
       visited.push(record);
 
-      if (!visited.has(target)) stack.push(collectEdges(graph, child));
+      if (!visited.has(target) && (maxDepth === undefined || stack.length < maxDepth)) stack.push(collectEdges(graph, child));
       else visited.pop();
     }
   }
@@ -262,12 +264,13 @@ function allSimpleEdgePaths(graph, source, target) {
  * Function returning all the compressed edge paths between source & target
  * in the graph.
  *
- * @param  {Graph}  graph  - Target graph.
- * @param  {string} source - Source node.
- * @param  {string} target - Target node.
- * @return {array}         - The found paths.
+ * @param  {Graph}  graph    - Target graph.
+ * @param  {string} source   - Source node.
+ * @param  {string} target   - Target node.
+ * @param  {number} maxDepth - Max traversal depth (default: no limit).
+ * @return {array}           - The found paths.
  */
-function allSimpleEdgeGroupPaths(graph, source, target) {
+function allSimpleEdgeGroupPaths(graph, source, target, maxDepth) {
   if (!isGraph(graph))
     throw new Error(
       'graphology-simple-path.allSimpleEdgeGroupPaths: expecting a graphology instance.'
@@ -319,7 +322,7 @@ function allSimpleEdgeGroupPaths(graph, source, target) {
 
       visited.push(record);
 
-      if (!visited.has(target)) stack.push(collectMultiEdges(graph, child));
+      if (!visited.has(target) && (maxDepth === undefined || stack.length < maxDepth)) stack.push(collectMultiEdges(graph, child));
       else visited.pop();
     }
   }


### PR DESCRIPTION
Added optional `maxDepth` argument to `allSimplePaths`, `allSimpleEdgePaths` and `allSimpleEdgeGroupPaths` to  limit traversal when searching for simple paths (as briefly mentioned in https://github.com/graphology/graphology/issues/391) 

The desired effect is analogous to using `cutoff` argument in popular Python library [networkx](https://networkx.org/documentation/stable/reference/algorithms/simple_paths.html)

*NOTE: This PR lacks updated tests!*