### PR TITLE
[types] Fix broken syntax (issue #452)

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -300,7 +300,7 @@ declare class GraphEventEmitter<Events extends EventsMapping> {
   emit<Event extends keyof Events>(
     type: Event,
     ...args: Parameters<Events[Event]>
-  ): boolean;AttributeUpdateType
+  ): boolean;
   addListener<Event extends keyof Events>(
     type: Event,
     listener: Events[Event]


### PR DESCRIPTION
Build error:
error TS7008: Member 'AttributeUpdateType' implicitly has an 'any' type.