### PR TITLE
Add type definition for undirectedSingleSourceLength

### DIFF
--- a/src/shortest-path/index.d.ts
+++ b/src/shortest-path/index.d.ts
@@ -5,6 +5,7 @@ export {
   singleSource,
   singleSourceLength,
   bidirectional,
+  undirectedSingleSourceLength,
   brandes
 } from './unweighted';
 

--- a/src/shortest-path/unweighted.d.ts
+++ b/src/shortest-path/unweighted.d.ts
@@ -26,4 +26,9 @@ export function singleSourceLength(
   source: unknown
 ): ShortestPathLengthMapping;
 
+export function undirectedSingleSourceLength(
+  graph: Graph,
+  node: unknown
+): ShortestPathLengthMapping;
+
 export function brandes(graph: Graph, source: unknown): BrandesResult;


### PR DESCRIPTION
fix https://github.com/graphology/graphology/issues/458

As the document says, `undirectedSingleSourceLength` should have the same signature as `singleSourceLength`
> This is basically the same as [singleSourceLength](https://graphology.github.io/standard-library/shortest-path#singlesourcelength) except that it will consider any given graph as undirected when traversing.