### PR TITLE
K-Core for graphology

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "graphology-communities-leiden": "file:src/communities-leiden",
     "graphology-communities-louvain": "file:src/communities-louvain",
     "graphology-components": "file:src/components",
+    "graphology-cores": "file:src/cores",
     "graphology-dag": "file:src/dag",
     "graphology-generators": "file:src/generators",
     "graphology-gexf": "file:src/gexf",

--- a/src/cores/.eslintrc.json
+++ b/src/cores/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@yomguithereal/eslint-config/es6", "eslint-config-prettier"]
+}

--- a/src/cores/README.md
+++ b/src/cores/README.md
@@ -46,8 +46,8 @@ coreNumber.assign(graph, 'core');
 
 _Arguments_
 
-* **graph** _Graph_: target graph.
-* **coreAttribute** _?string_ : the name of the attribute to use if core numbers are assigned to the nodes.
+- **graph** _Graph_: target graph.
+- **coreAttribute** _?string_ : the name of the attribute to use if core numbers are assigned to the nodes.
 
 ### kCore
 
@@ -65,9 +65,9 @@ const core = kCore(graph, 4);
 
 _Arguments_
 
-* **graph** _Graph_: target graph.
-* **k** _?number_: custom k value to use.
-* **customCore** _?object_: custom core numbers to use.
+- **graph** _Graph_: target graph.
+- **k** _?number_: custom k value to use.
+- **customCore** _?object_: custom core numbers to use.
 
 ### kShell
 
@@ -85,9 +85,9 @@ const shell = kShell(graph, 5);
 
 _Arguments_
 
-* **graph** _Graph_: target graph.
-* **k** _?number_: custom k value to use.
-* **customCore** _?object_: custom core numbers to use.
+- **graph** _Graph_: target graph.
+- **k** _?number_: custom k value to use.
+- **customCore** _?object_: custom core numbers to use.
 
 ### kCrust
 
@@ -105,9 +105,9 @@ const crust = kCrust(graph, 4);
 
 _Arguments_
 
-* **graph** _Graph_: target graph.
-* **k** _?number_: custom k value to use.
-* **customCore** _?object_: custom core numbers to use.
+- **graph** _Graph_: target graph.
+- **k** _?number_: custom k value to use.
+- **customCore** _?object_: custom core numbers to use.
 
 ### kCorona
 
@@ -125,9 +125,9 @@ const corona = kCorona(graph, 4);
 
 _Arguments_
 
-* **graph** _Graph_: target graph.
-* **k** _?number_: custom k value to use.
-* **customCore** _?object_: custom core numbers to use.
+- **graph** _Graph_: target graph.
+- **k** _?number_: custom k value to use.
+- **customCore** _?object_: custom core numbers to use.
 
 ### onionLayers
 
@@ -150,6 +150,5 @@ onionLayers.assign(graph, 'onion');
 
 _Arguments_
 
-* **graph** _Graph_: target graph.
-* **onionLayerAttribute** _?string_ : the name of the attribute to use if onion layers are assigned to the nodes.
-
+- **graph** _Graph_: target graph.
+- **onionLayerAttribute** _?string_ : the name of the attribute to use if onion layers are assigned to the nodes.

--- a/src/cores/README.md
+++ b/src/cores/README.md
@@ -23,6 +23,7 @@ npm install graphology-cores
 - [kShell](#kshell)
 - [kCrust](#kcrust)
 - [kCorona](#kcorona)
+- [kTruss](#ktruss)
 - [onionLayers](#onionlayers)
 
 ### coreNumber
@@ -47,7 +48,7 @@ coreNumber.assign(graph, 'core');
 _Arguments_
 
 - **graph** _Graph_: target graph.
-- **coreAttribute** _?string_ : the name of the attribute to use if core numbers are assigned to the nodes.
+- **nodeCoreAttribute** _?string_ : the name of the attribute to use if core numbers are assigned to the nodes.
 
 ### kCore
 
@@ -129,6 +130,24 @@ _Arguments_
 - **k** _?number_: custom k value to use.
 - **customCore** _?object_: custom core numbers to use.
 
+### kTruss
+
+Returns the k-truss subgraph. K-Truss subgraph contains at least three nodes for which every edge is incident to at least `k-2` triangles.
+
+K-Truss is not implemented for directed graphs and multigraphs.
+
+```js
+import kTruss from 'graphology-cores/kTruss';
+
+// Return the k-truss of the graph with k = 4
+const truss = kTruss(graph, 4);
+```
+
+_Arguments_
+
+- **graph** _Graph_: target graph.
+- **k** _number_: k value to use.
+
 ### onionLayers
 
 Computes the onion decomposition of a given graph. Onion layers can't be calculated if the graph is directed.
@@ -151,4 +170,4 @@ onionLayers.assign(graph, 'onion');
 _Arguments_
 
 - **graph** _Graph_: target graph.
-- **onionLayerAttribute** _?string_ : the name of the attribute to use if onion layers are assigned to the nodes.
+- **nodeOnionLayerAttribute** _?string_ : the name of the attribute to use if onion layers are assigned to the nodes.

--- a/src/cores/README.md
+++ b/src/cores/README.md
@@ -1,0 +1,155 @@
+# Graphology Cores
+
+Various functions related to the k-core of graphs to be used with [graphology](https://graphology.github.io).
+
+The k-core of a graph is the maximal connected subgraph in which all nodes have a degree of k or more. The main core of a graph is the k-core subgraph with the highest possible k.
+
+If the graph is directed, nodes' degree are considered as the sum of all the inbound and outbound neighbors of the node.
+
+> An O(m) Algorithm for Cores Decomposition of Networks Vladimir Batagelj and Matjaz Zaversnik, 2003. [https://arxiv.org/abs/cs.DS/0310049](https://arxiv.org/abs/cs.DS/0310049)
+
+> Generalized Cores Vladimir Batagelj and Matjaz Zaversnik, 2002. [https://arxiv.org/pdf/cs/0202039](https://arxiv.org/pdf/cs/0202039)
+
+## Installation
+
+```
+npm install graphology-cores
+```
+
+## Usage
+
+- [coreNumber](#corenumber)
+- [kCore](#kcore)
+- [kShell](#kshell)
+- [kCrust](#kcrust)
+- [kCorona](#kcorona)
+- [onionLayers](#onionlayers)
+
+### coreNumber
+
+Returns the core number for each node. The core number of a node is the largest k of a k-core subgraph containing this node.
+
+This implementation doesn't allow graphs with parallel edges or self loops.
+
+```js
+import coreNumber from 'graphology-cores/coreNumber';
+
+// Return the core number for each node
+const numbers = coreNumber(graph);
+
+// Assign to each node its core number
+coreNumber.assign(graph);
+
+// Assign with a custom attribute label
+coreNumber.assign(graph, 'core');
+```
+
+_Arguments_
+
+* **graph** _Graph_: target graph.
+* **coreAttribute** _?string_ : the name of the attribute to use if core numbers are assigned to the nodes.
+
+### kCore
+
+Returns the maximal connected subgraph containing nodes with k degree or more. If k isn't provided, k is the highest core number present in the graph.
+
+```js
+import kCore from 'graphology-cores/kCore';
+
+// Return the main k-core of the graph
+const core = kCore(graph);
+
+// Return the k-core subgraph with an arbitrary k value
+const core = kCore(graph, 4);
+```
+
+_Arguments_
+
+* **graph** _Graph_: target graph.
+* **k** _?number_: custom k value to use.
+* **customCore** _?object_: custom core numbers to use.
+
+### kShell
+
+Returns the k-shell subgraph. K-Shell subgraph is the maximal connected subgraph containing the nodes with k degree.
+
+```js
+import kShell from 'graphology-cores/kShell';
+
+// Return the main k-shell of the graph
+const shell = kShell(graph);
+
+// Return the k-shell subgraph with an arbitrary k value
+const shell = kShell(graph, 5);
+```
+
+_Arguments_
+
+* **graph** _Graph_: target graph.
+* **k** _?number_: custom k value to use.
+* **customCore** _?object_: custom core numbers to use.
+
+### kCrust
+
+Returns the k-crust subgraph. K-Crust subgraph is the maximal connected subgraph containing nodes with less than k degree.
+
+```js
+import kCrust from 'graphology-cores/kCrust';
+
+// Return the main k-crust of the graph
+const crust = kCrust(graph);
+
+// Return the k-crust subgraph with an arbitrary k value
+const crust = kCrust(graph, 4);
+```
+
+_Arguments_
+
+* **graph** _Graph_: target graph.
+* **k** _?number_: custom k value to use.
+* **customCore** _?object_: custom core numbers to use.
+
+### kCorona
+
+Returns the k-corona subgraph. K-Corona subgraph contains nodes in the k-core with exactly k neighbors in the k-core.
+
+```js
+import kCorona from 'graphology-cores/kCorona';
+
+// Return the main k-corona of the graph
+const corona = kCorona(graph);
+
+// Return the k-corona subgraph with an arbitrary k value
+const corona = kCorona(graph, 4);
+```
+
+_Arguments_
+
+* **graph** _Graph_: target graph.
+* **k** _?number_: custom k value to use.
+* **customCore** _?object_: custom core numbers to use.
+
+### onionLayers
+
+Computes the onion decomposition of a given graph. Onion layers can't be calculated if the graph is directed.
+
+> Multi-scale structure and topological anomaly detection via a new network statistic: The onion decomposition L. Hébert-Dufresne, J. A. Grochow, and A. Allard Scientific Reports 6, 31708 (2016) [http://doi.org/10.1038/srep31708](http://doi.org/10.1038/srep31708)
+
+```js
+import onionLayers from 'graphology-cores/onionLayers';
+
+// Return the onion layers for each node
+const onion = onionLayers(graph);
+
+// Assign to each node its onion layer
+onionLayers.assign(graph);
+
+// Assign with a custom attribute label
+onionLayers.assign(graph, 'onion');
+```
+
+_Arguments_
+
+* **graph** _Graph_: target graph.
+* **onionLayerAttribute** _?string_ : the name of the attribute to use if onion layers are assigned to the nodes.
+

--- a/src/cores/index.d.ts
+++ b/src/cores/index.d.ts
@@ -1,3 +1,61 @@
-import Graph from 'graphology-types';
+import Graph, {Attributes} from 'graphology-types';
 
-// No idea what to put here :3
+export function coreNumber<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes,
+  GraphAttributes extends Attributes = Attributes
+>(
+  assign: boolean,
+  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
+  coreAttributes?: string
+): Record<string, number>;
+
+export function kCore<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes,
+  GraphAttributes extends Attributes = Attributes
+>(
+  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  k?: number,
+  customCore?: Record<string, number>
+): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+
+export function kShell<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes,
+  GraphAttributes extends Attributes = Attributes
+>(
+  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  k?: number,
+  customCore?: Record<string, number>
+): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+
+export function kCrust<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes,
+  GraphAttributes extends Attributes = Attributes
+>(
+  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  k?: number,
+  customCore?: Record<string, number>
+): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+
+export function kCorona<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes,
+  GraphAttributes extends Attributes = Attributes
+>(
+  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  k?: number,
+  customCore?: Record<string, number>
+): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+
+export function onionLayers<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes,
+  GraphAttributes extends Attributes = Attributes
+>(
+  assign: boolean,
+  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
+  onionLayerAttribute?: string
+): Record<string, number>;

--- a/src/cores/index.d.ts
+++ b/src/cores/index.d.ts
@@ -1,0 +1,3 @@
+import Graph from 'graphology-types';
+
+// No idea what to put here :3

--- a/src/cores/index.d.ts
+++ b/src/cores/index.d.ts
@@ -1,12 +1,8 @@
 import Graph, {Attributes} from 'graphology-types';
 
-export function coreNumber<
-  NodeAttributes extends Attributes = Attributes,
-  EdgeAttributes extends Attributes = Attributes,
-  GraphAttributes extends Attributes = Attributes
->(
+export function coreNumber(
   assign: boolean,
-  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
+  graph: Graph,
   coreAttributes?: string
 ): Record<string, number>;
 
@@ -15,47 +11,52 @@ export function kCore<
   EdgeAttributes extends Attributes = Attributes,
   GraphAttributes extends Attributes = Attributes
 >(
-  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
   k?: number,
   customCore?: Record<string, number>
-): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+): Graph<NodeAttributes, EdgeAttributes, GraphAttributes>;
 
 export function kShell<
   NodeAttributes extends Attributes = Attributes,
   EdgeAttributes extends Attributes = Attributes,
   GraphAttributes extends Attributes = Attributes
 >(
-  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
   k?: number,
   customCore?: Record<string, number>
-): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+): Graph<NodeAttributes, EdgeAttributes, GraphAttributes>;
 
 export function kCrust<
   NodeAttributes extends Attributes = Attributes,
   EdgeAttributes extends Attributes = Attributes,
   GraphAttributes extends Attributes = Attributes
 >(
-  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
   k?: number,
   customCore?: Record<string, number>
-): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+): Graph<NodeAttributes, EdgeAttributes, GraphAttributes>;
 
 export function kCorona<
   NodeAttributes extends Attributes = Attributes,
   EdgeAttributes extends Attributes = Attributes,
   GraphAttributes extends Attributes = Attributes
 >(
-  graph: Graph<EdgeAttributes, NodeAttributes, GraphAttributes>,
+  graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
   k?: number,
   customCore?: Record<string, number>
-): Graph<EdgeAttributes, NodeAttributes, GraphAttributes>;
+): Graph<NodeAttributes, EdgeAttributes, GraphAttributes>;
 
-export function onionLayers<
+export function kTruss<
   NodeAttributes extends Attributes = Attributes,
   EdgeAttributes extends Attributes = Attributes,
   GraphAttributes extends Attributes = Attributes
 >(
-  assign: boolean,
   graph: Graph<NodeAttributes, EdgeAttributes, GraphAttributes>,
+  k: number
+): Graph<NodeAttributes, EdgeAttributes, GraphAttributes>;
+
+export function onionLayers(
+  assign: boolean,
+  graph: Graph,
   onionLayerAttribute?: string
 ): Record<string, number>;

--- a/src/cores/index.js
+++ b/src/cores/index.js
@@ -8,13 +8,6 @@
 const isGraph = require('graphology-utils/is-graph');
 const subgraph = require('graphology-operators/subgraph');
 
-/**
- * Abstract function computing core order for every node of a graph.
- *
- * @param  {boolean} assign                      - Assign the results to node attributes?
- * @param  {Graph}   graph                       - Target graph.
- * @param  {object}  onionLayerAttribute         - Name of the attribute to assign.
- */
 function coreNumber(assign, graph, coreAttribute) {
   coreAttribute = coreAttribute || 'core';
 
@@ -139,14 +132,14 @@ function kCore(graph, k, customCore) {
   );
 }
 
-function kShell(graph, k, core) {
+function kShell(graph, k, customCore) {
   return coreSubgraph(
     graph,
     (cv, ck, cc) => {
       return cc[cv] === ck;
     },
     k,
-    core
+    customCore
   );
 }
 
@@ -183,13 +176,6 @@ function kCorona(graph, k, customCore) {
   );
 }
 
-/**
- * Abstract function computing onion lyers of the given graph.
- *
- * @param  {boolean} assign                      - Assign the results to node attributes?
- * @param  {Graph}   graph                       - Target graph.
- * @param  {object}  onionLayerAttribute         - Name of the attribute to assign.
- */
 function onionLayers(assign, graph, onionLayerAttribute) {
   onionLayerAttribute = onionLayerAttribute || 'onionLayer';
 

--- a/src/cores/index.js
+++ b/src/cores/index.js
@@ -16,153 +16,171 @@ const subgraph = require('graphology-operators/subgraph');
  * @param  {object}  onionLayerAttribute         - Name of the attribute to assign.
  */
 function coreNumber(assign, graph, coreAttribute) {
-    coreAttribute = coreAttribute || "core";
+  coreAttribute = coreAttribute || 'core';
 
-    if (!isGraph(graph))
-        throw new Error(
-            'graphology-metrics/core: the given graph is not a valid graphology instance.'
-        );
+  if (!isGraph(graph))
+    throw new Error(
+      'graphology-metrics/core: the given graph is not a valid graphology instance.'
+    );
 
-    if (graph.selfLoopCount > 0)
-        throw new Error(
-            'graphology-metrics/core: the given graph has self loops which is not permitted.'
-        );
+  if (graph.selfLoopCount > 0)
+    throw new Error(
+      'graphology-metrics/core: the given graph has self loops which is not permitted.'
+    );
 
-    const degrees = {};
+  const degrees = {};
+  graph.forEachNode(node => {
+    degrees[node] = graph.degree(node);
+  });
+
+  // Sort nodes by degree
+  const nodes = Object.entries(degrees)
+    .sort((a, b) => {
+      const d1 = a[1];
+      const d2 = b[1];
+      return d1 - d2;
+    })
+    .map(a => {
+      return a[0];
+    });
+
+  const binBounderie = [0];
+  let currDegree = 0;
+
+  // Preparing bin_bounderie
+  for (let i = 0; i < nodes.length; ++i) {
+    const node = nodes[i];
+    const nd = degrees[node];
+    if (nd > currDegree) {
+      let l = nd - currDegree;
+      while (l--) binBounderie.push(i);
+      currDegree = nd;
+    }
+  }
+
+  // Node positions
+  const nodePos = {};
+
+  for (let i = 0; i < nodes.length; ++i) {
+    const nd = nodes[i];
+    nodePos[nd] = i;
+  }
+
+  // Neighbors
+  const nbrs = {};
+  nodes.forEach(node => {
+    nbrs[node] = [];
+    graph.forEachInboundNeighbor(node, nbr => {
+      nbrs[node].push(nbr);
+    });
+    graph.forEachOutboundNeighbor(node, nbr => {
+      nbrs[node].push(nbr);
+    });
+  });
+
+  const removed = new Set();
+  const core = degrees;
+  nodes.forEach(node => {
+    nbrs[node].forEach(nbr => {
+      if (core[nbr] > core[node]) {
+        if (removed.has([node, nbr])) return;
+        removed.add([nbr, node]);
+        const pos = nodePos[nbr];
+        const binStart = binBounderie[core[nbr]];
+        nodePos[nbr] = binStart;
+        nodePos[nodes[binStart]] = pos;
+
+        const stemp = nodes[binStart];
+        nodes[binStart] = nodes[pos];
+        nodes[pos] = stemp;
+
+        binBounderie[core[nbr]] += 1;
+        core[nbr] -= 1;
+      }
+    });
+  });
+
+  if (assign) {
     graph.forEachNode(node => {
-        degrees[node] = graph.degree(node);
-    })
-
-    // Sort nodes by degree
-    const nodes = Object.entries(degrees).sort((a, b) => {
-        const d1 = a[1];
-        const d2 = b[1];
-        return d1 - d2;
-    }).map( a => {
-        return a[0];
+      graph.setNodeAttribute(node, coreAttribute, core[node]);
     });
+  }
 
-    const binBounderie = [0];
-    let currDegree = 0;
-
-    // Preparing bin_bounderie
-    for (let i = 0; i < nodes.length; ++i) {
-        const node = nodes[i];
-        const nd = degrees[node];
-        if (nd > currDegree) {
-            let l = (nd - currDegree);
-            while (l--) binBounderie.push(i);
-            currDegree = nd;
-        }
-    }
-
-    // Node positions
-    const nodePos = {}
-
-    for (let i = 0; i < nodes.length; ++i) {
-        const nd = nodes[i];
-        nodePos[nd] = i;
-    }
-
-
-    // Neighbors
-    const nbrs = {};
-    nodes.forEach(node => {
-        nbrs[node] = []
-        graph.forEachInboundNeighbor(node, nbr => {
-            nbrs[node].push(nbr);
-        });
-        graph.forEachOutboundNeighbor(node, nbr => {
-            nbrs[node].push(nbr);
-        });
-    })
-
-    const removed = new Set();
-    const core = degrees;
-    nodes.forEach(node => {
-        nbrs[node].forEach(nbr => {
-            if (core[nbr] > core[node]) {
-                if (removed.has([node, nbr])) return;
-                removed.add([nbr, node]);
-                const pos = nodePos[nbr];
-                const binStart = binBounderie[core[nbr]];
-                nodePos[nbr] = binStart;
-                nodePos[nodes[binStart]] = pos;
-
-                const stemp = nodes[binStart];
-                nodes[binStart] = nodes[pos];
-                nodes[pos] = stemp;
-
-                binBounderie[core[nbr]] += 1;
-                core[nbr] -= 1;
-            }
-        });
-    });
-
-    if (assign) {
-        graph.forEachNode(node => {
-            graph.setNodeAttribute(node, coreAttribute, core[node]);
-        })
-    }
-
-    return core;
+  return core;
 }
 
 function coreSubgraph(graph, filter, k, customCore) {
-    if (customCore === undefined) {
-        customCore = coreNumber(false, graph);
+  if (customCore === undefined) {
+    customCore = coreNumber(false, graph);
+  }
+  if (k === undefined) {
+    k = Math.max.apply(Math, Object.values(customCore));
+  }
+  const nodes = [];
+  Object.entries(customCore).forEach(pair => {
+    const node = pair[0];
+    if (filter(node, k, customCore)) {
+      nodes.push(node);
     }
-    if (k === undefined) {
-        k = Math.max.apply(Math, Object.values(customCore));
-    }
-    const nodes = [];
-    Object.entries(customCore).forEach(pair => {
-        const node = pair[0];
-        if (filter(node, k, customCore)) {
-            nodes.push(node);
-        }
-    })
-    return subgraph(graph, nodes);
+  });
+  return subgraph(graph, nodes);
 }
 
 // ===== Filters =====
 
 function kCore(graph, k, customCore) {
-    return coreSubgraph(graph, (cv, ck, cc) => {
-        return cc[cv] >= ck;
-    }, k, customCore);
+  return coreSubgraph(
+    graph,
+    (cv, ck, cc) => {
+      return cc[cv] >= ck;
+    },
+    k,
+    customCore
+  );
 }
 
 function kShell(graph, k, core) {
-    return coreSubgraph(graph, (cv, ck, cc) => {
-        return cc[cv] === ck;
-    }, k, core);
+  return coreSubgraph(
+    graph,
+    (cv, ck, cc) => {
+      return cc[cv] === ck;
+    },
+    k,
+    core
+  );
 }
 
 function kCrust(graph, k, customCore) {
-    if (customCore === undefined) {
-        customCore = coreNumber(false, graph);
-    }
-    if (k === undefined) {
-        k = Math.max.apply(Math, Object.values(customCore)) - 1;
-    }
-    const nodes = [];
-    Object.entries(customCore).forEach(pair => {
-        const [node, cn] = pair;
-        if (cn <= k) nodes.push(node);
-    })
-    return subgraph(graph, nodes);
+  if (customCore === undefined) {
+    customCore = coreNumber(false, graph);
+  }
+  if (k === undefined) {
+    k = Math.max.apply(Math, Object.values(customCore)) - 1;
+  }
+  const nodes = [];
+  Object.entries(customCore).forEach(pair => {
+    const [node, cn] = pair;
+    if (cn <= k) nodes.push(node);
+  });
+  return subgraph(graph, nodes);
 }
 
 function kCorona(graph, k, customCore) {
-    return coreSubgraph(graph, (cv, ck, cc) => {
-        const nbrsSum = graph.inboundNeighbors(cv).reduce((acc, nb) => {
-            return cc[nb] >= ck ? acc + 1 : acc
-        }, 0) + graph.outboundNeighbors(cv).reduce((acc, nb) => {
-            return cc[nb] >= ck ? acc + 1 : acc
+  return coreSubgraph(
+    graph,
+    (cv, ck, cc) => {
+      const nbrsSum =
+        graph.inboundNeighbors(cv).reduce((acc, nb) => {
+          return cc[nb] >= ck ? acc + 1 : acc;
+        }, 0) +
+        graph.outboundNeighbors(cv).reduce((acc, nb) => {
+          return cc[nb] >= ck ? acc + 1 : acc;
         }, 0);
-        return cc[cv] === ck && ck === nbrsSum;
-    }, k, customCore);
+      return cc[cv] === ck && ck === nbrsSum;
+    },
+    k,
+    customCore
+  );
 }
 
 /**
@@ -173,89 +191,95 @@ function kCorona(graph, k, customCore) {
  * @param  {object}  onionLayerAttribute         - Name of the attribute to assign.
  */
 function onionLayers(assign, graph, onionLayerAttribute) {
-    onionLayerAttribute = onionLayerAttribute || "onionLayer";
+  onionLayerAttribute = onionLayerAttribute || 'onionLayer';
 
-    const remove = function (degrees, key) {
-        return Object.keys(degrees).reduce((acc, k) => {
-            if (k !== key) acc[k] = degrees[k]
-            return acc;
-        }, {});
-    };
+  const remove = function (degrees, key) {
+    return Object.keys(degrees).reduce((acc, k) => {
+      if (k !== key) acc[k] = degrees[k];
+      return acc;
+    }, {});
+  };
 
-    if (graph.type === 'directed' || graph.multi) {
-        throw Error('graphology-metrics/core : unimplemented metric for directed graphs and multigraphs.')
+  if (graph.type === 'directed' || graph.multi) {
+    throw Error(
+      'graphology-metrics/core : unimplemented metric for directed graphs and multigraphs.'
+    );
+  }
+
+  if (graph.selfLoopCount > 0) {
+    throw Error(
+      'graphology-metrics/core : onion loyers not available for graphs with self-loops.'
+    );
+  }
+
+  let degrees = {};
+  const neighbors = {};
+  const isolatedNodes = [];
+  graph.forEachNode(node => {
+    // Adding degrees
+    const deg = graph.degree(node);
+    degrees[node] = deg;
+    // Adding isolated nodes
+    if (deg === 0) isolatedNodes.push(node);
+    // Setting up neighbors
+    neighbors[node] = graph.neighbors(node);
+  });
+
+  const odLayers = {};
+  let currentCore = 1;
+  let currentLayer = 1;
+
+  // Isolated nodes
+  if (isolatedNodes.length > 0) {
+    isolatedNodes.forEach(node => {
+      odLayers[node] = currentLayer;
+      degrees = remove(degrees, node);
+    });
+    currentLayer += 1;
+  }
+  // Others
+  let degreesEntries = null;
+  while ((degreesEntries = Object.entries(degrees)).length > 0) {
+    const nodes = degreesEntries
+      .sort((a, b) => {
+        const d1 = a[1];
+        const d2 = b[1];
+        return d1 - d2;
+      })
+      .map(a => {
+        const n = a[0];
+        return n;
+      });
+
+    const minDegree = degrees[nodes[0]];
+    if (minDegree > currentCore) currentCore = minDegree;
+
+    const thisLayer = [];
+    for (let i = 0; i < nodes.length; ++i) {
+      if (degrees[nodes[i]] > currentCore) break;
+      thisLayer.push(nodes[i]);
+    }
+    for (let i = 0; i < thisLayer.length; ++i) {
+      const node = thisLayer[i];
+      odLayers[node] = currentLayer;
+      for (let n = 0; n < neighbors[node].length; ++n) {
+        const nbr = neighbors[node][n];
+        neighbors[nbr].splice(neighbors[nbr].indexOf(node), 1);
+        degrees[nbr] -= 1;
+      }
+      degrees = remove(degrees, node);
     }
 
-    if (graph.selfLoopCount > 0) {
-        throw Error('graphology-metrics/core : onion loyers not available for graphs with self-loops.')
-    }
+    currentLayer++;
+  }
 
-    let degrees = {}
-    const neighbors = {}
-    const isolatedNodes = []
+  if (assign) {
     graph.forEachNode(node => {
-        // Adding degrees
-        const deg = graph.degree(node);
-        degrees[node] = deg;
-        // Adding isolated nodes
-        if (deg === 0) isolatedNodes.push(node);
-        // Setting up neighbors
-        neighbors[node] = graph.neighbors(node);
-    })
+      graph.setNodeAttribute(node, onionLayerAttribute, odLayers[node]);
+    });
+  }
 
-    const odLayers = {}
-    let currentCore = 1;
-    let currentLayer = 1;
-
-    // Isolated nodes
-    if (isolatedNodes.length > 0) {
-        isolatedNodes.forEach(node => {
-            odLayers[node] = currentLayer;
-            degrees = remove(degrees, node);
-        });
-        currentLayer += 1;
-    }
-    // Others
-    let degreesEntries = null;
-    while ((degreesEntries = Object.entries(degrees)).length > 0) {
-        const nodes = degreesEntries.sort((a, b) => {
-            const d1 = a[1];
-            const d2 = b[1];
-            return d1 - d2;
-        }).map(a => {
-            const n = a[0];
-            return n;
-        });
-
-        const minDegree = degrees[nodes[0]];
-        if (minDegree > currentCore) currentCore = minDegree;
-
-        const thisLayer = [];
-        for (let i = 0; i < nodes.length; ++i) {
-            if (degrees[nodes[i]] > currentCore) break;
-            thisLayer.push(nodes[i]);
-        }
-        for (let i = 0; i < thisLayer.length; ++i) {
-            const node = thisLayer[i];
-            odLayers[node] = currentLayer;
-            for (let n = 0; n < neighbors[node].length; ++n) {
-                const nbr = neighbors[node][n];
-                neighbors[nbr].splice(neighbors[nbr].indexOf(node), 1);
-                degrees[nbr] -= 1;
-            }
-            degrees = remove(degrees, node);
-        }
-
-        currentLayer++;
-    }
-
-    if (assign) {
-        graph.forEachNode(node => {
-            graph.setNodeAttribute(node, onionLayerAttribute, odLayers[node]);
-        })
-    }
-
-    return odLayers;
+  return odLayers;
 }
 
 exports.coreNumber = coreNumber.bind(null, false);

--- a/src/cores/index.js
+++ b/src/cores/index.js
@@ -1,0 +1,269 @@
+/**
+ * Graphology Core Metrics
+ * ===========================
+ *
+ * Functions computing the metrics related to the core
+ * of a given graph.
+ */
+const isGraph = require('graphology-utils/is-graph');
+const subgraph = require('graphology-operators/subgraph');
+
+/**
+ * Abstract function computing core order for every node of a graph.
+ *
+ * @param  {boolean} assign                      - Assign the results to node attributes?
+ * @param  {Graph}   graph                       - Target graph.
+ * @param  {object}  onionLayerAttribute         - Name of the attribute to assign.
+ */
+function coreNumber(assign, graph, coreAttribute) {
+    coreAttribute = coreAttribute || "core";
+
+    if (!isGraph(graph))
+        throw new Error(
+            'graphology-metrics/core: the given graph is not a valid graphology instance.'
+        );
+
+    if (graph.selfLoopCount > 0)
+        throw new Error(
+            'graphology-metrics/core: the given graph has self loops which is not permitted.'
+        );
+
+    const degrees = {};
+    graph.forEachNode(node => {
+        degrees[node] = graph.degree(node);
+    })
+
+    // Sort nodes by degree
+    const nodes = Object.entries(degrees).sort((a, b) => {
+        const d1 = a[1];
+        const d2 = b[1];
+        return d1 - d2;
+    }).map( a => {
+        return a[0];
+    });
+
+    const binBounderie = [0];
+    let currDegree = 0;
+
+    // Preparing bin_bounderie
+    for (let i = 0; i < nodes.length; ++i) {
+        const node = nodes[i];
+        const nd = degrees[node];
+        if (nd > currDegree) {
+            let l = (nd - currDegree);
+            while (l--) binBounderie.push(i);
+            currDegree = nd;
+        }
+    }
+
+    // Node positions
+    const nodePos = {}
+
+    for (let i = 0; i < nodes.length; ++i) {
+        const nd = nodes[i];
+        nodePos[nd] = i;
+    }
+
+
+    // Neighbors
+    const nbrs = {};
+    nodes.forEach(node => {
+        nbrs[node] = []
+        graph.forEachInboundNeighbor(node, nbr => {
+            nbrs[node].push(nbr);
+        });
+        graph.forEachOutboundNeighbor(node, nbr => {
+            nbrs[node].push(nbr);
+        });
+    })
+
+    const removed = new Set();
+    const core = degrees;
+    nodes.forEach(node => {
+        nbrs[node].forEach(nbr => {
+            if (core[nbr] > core[node]) {
+                if (removed.has([node, nbr])) return;
+                removed.add([nbr, node]);
+                const pos = nodePos[nbr];
+                const binStart = binBounderie[core[nbr]];
+                nodePos[nbr] = binStart;
+                nodePos[nodes[binStart]] = pos;
+
+                const stemp = nodes[binStart];
+                nodes[binStart] = nodes[pos];
+                nodes[pos] = stemp;
+
+                binBounderie[core[nbr]] += 1;
+                core[nbr] -= 1;
+            }
+        });
+    });
+
+    if (assign) {
+        graph.forEachNode(node => {
+            graph.setNodeAttribute(node, coreAttribute, core[node]);
+        })
+    }
+
+    return core;
+}
+
+function coreSubgraph(graph, filter, k, customCore) {
+    if (customCore === undefined) {
+        customCore = coreNumber(false, graph);
+    }
+    if (k === undefined) {
+        k = Math.max.apply(Math, Object.values(customCore));
+    }
+    const nodes = [];
+    Object.entries(customCore).forEach(pair => {
+        const node = pair[0];
+        if (filter(node, k, customCore)) {
+            nodes.push(node);
+        }
+    })
+    return subgraph(graph, nodes);
+}
+
+// ===== Filters =====
+
+function kCore(graph, k, customCore) {
+    return coreSubgraph(graph, (cv, ck, cc) => {
+        return cc[cv] >= ck;
+    }, k, customCore);
+}
+
+function kShell(graph, k, core) {
+    return coreSubgraph(graph, (cv, ck, cc) => {
+        return cc[cv] === ck;
+    }, k, core);
+}
+
+function kCrust(graph, k, customCore) {
+    if (customCore === undefined) {
+        customCore = coreNumber(false, graph);
+    }
+    if (k === undefined) {
+        k = Math.max.apply(Math, Object.values(customCore)) - 1;
+    }
+    const nodes = [];
+    Object.entries(customCore).forEach(pair => {
+        const [node, cn] = pair;
+        if (cn <= k) nodes.push(node);
+    })
+    return subgraph(graph, nodes);
+}
+
+function kCorona(graph, k, customCore) {
+    return coreSubgraph(graph, (cv, ck, cc) => {
+        const nbrsSum = graph.inboundNeighbors(cv).reduce((acc, nb) => {
+            return cc[nb] >= ck ? acc + 1 : acc
+        }, 0) + graph.outboundNeighbors(cv).reduce((acc, nb) => {
+            return cc[nb] >= ck ? acc + 1 : acc
+        }, 0);
+        return cc[cv] === ck && ck === nbrsSum;
+    }, k, customCore);
+}
+
+/**
+ * Abstract function computing onion lyers of the given graph.
+ *
+ * @param  {boolean} assign                      - Assign the results to node attributes?
+ * @param  {Graph}   graph                       - Target graph.
+ * @param  {object}  onionLayerAttribute         - Name of the attribute to assign.
+ */
+function onionLayers(assign, graph, onionLayerAttribute) {
+    onionLayerAttribute = onionLayerAttribute || "onionLayer";
+
+    const remove = function (degrees, key) {
+        return Object.keys(degrees).reduce((acc, k) => {
+            if (k !== key) acc[k] = degrees[k]
+            return acc;
+        }, {});
+    };
+
+    if (graph.type === 'directed' || graph.multi) {
+        throw Error('graphology-metrics/core : unimplemented metric for directed graphs and multigraphs.')
+    }
+
+    if (graph.selfLoopCount > 0) {
+        throw Error('graphology-metrics/core : onion loyers not available for graphs with self-loops.')
+    }
+
+    let degrees = {}
+    const neighbors = {}
+    const isolatedNodes = []
+    graph.forEachNode(node => {
+        // Adding degrees
+        const deg = graph.degree(node);
+        degrees[node] = deg;
+        // Adding isolated nodes
+        if (deg === 0) isolatedNodes.push(node);
+        // Setting up neighbors
+        neighbors[node] = graph.neighbors(node);
+    })
+
+    const odLayers = {}
+    let currentCore = 1;
+    let currentLayer = 1;
+
+    // Isolated nodes
+    if (isolatedNodes.length > 0) {
+        isolatedNodes.forEach(node => {
+            odLayers[node] = currentLayer;
+            degrees = remove(degrees, node);
+        });
+        currentLayer += 1;
+    }
+    // Others
+    let degreesEntries = null;
+    while ((degreesEntries = Object.entries(degrees)).length > 0) {
+        const nodes = degreesEntries.sort((a, b) => {
+            const d1 = a[1];
+            const d2 = b[1];
+            return d1 - d2;
+        }).map(a => {
+            const n = a[0];
+            return n;
+        });
+
+        const minDegree = degrees[nodes[0]];
+        if (minDegree > currentCore) currentCore = minDegree;
+
+        const thisLayer = [];
+        for (let i = 0; i < nodes.length; ++i) {
+            if (degrees[nodes[i]] > currentCore) break;
+            thisLayer.push(nodes[i]);
+        }
+        for (let i = 0; i < thisLayer.length; ++i) {
+            const node = thisLayer[i];
+            odLayers[node] = currentLayer;
+            for (let n = 0; n < neighbors[node].length; ++n) {
+                const nbr = neighbors[node][n];
+                neighbors[nbr].splice(neighbors[nbr].indexOf(node), 1);
+                degrees[nbr] -= 1;
+            }
+            degrees = remove(degrees, node);
+        }
+
+        currentLayer++;
+    }
+
+    if (assign) {
+        graph.forEachNode(node => {
+            graph.setNodeAttribute(node, onionLayerAttribute, odLayers[node]);
+        })
+    }
+
+    return odLayers;
+}
+
+exports.coreNumber = coreNumber.bind(null, false);
+exports.coreNumber.assign = coreNumber.bind(null, true);
+exports.onionLayers = onionLayers.bind(null, false);
+exports.onionLayers.assign = onionLayers.bind(null, true);
+
+exports.kCore = kCore;
+exports.kShell = kShell;
+exports.kCrust = kCrust;
+exports.kCorona = kCorona;

--- a/src/cores/package.json
+++ b/src/cores/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "graphology-cores",
+  "version": "0.0.1",
+  "description": "Functions computing the metrics related to the degeneracy.",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "*.d.ts"
+  ],
+  "types": "./index.d.ts",
+  "scripts": {
+    "prepublishOnly": "npm test",
+    "test": "mocha test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/graphology/graphology.git"
+  },
+  "keywords": [
+    "graph",
+    "graphology",
+    "core",
+    "degeneracy"
+  ],
+  "contributors": [
+    {
+      "name": "Guillaume Plique",
+      "url": "http://github.com/Yomguithereal"
+    },
+    {
+      "name": "César Pichon",
+      "url": "http://github.com/16arpi"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/graphology/graphology/issues"
+  },
+  "homepage": "https://github.com/graphology/graphology#readme",
+  "peerDependencies": {
+    "graphology-types": ">=0.19.0"
+  },
+  "dependencies": {
+    "graphology-utils": "^2.4.1"
+  }
+}

--- a/src/cores/test.js
+++ b/src/cores/test.js
@@ -3,7 +3,7 @@ const core = require('./index');
 const assert = require('assert');
 
 function prepareGraphG() {
-  const G = new graphology.Graph();
+  const G = new graphology.UndirectedGraph();
   G.mergeEdge(4, 1);
   G.mergeEdge(4, 2);
   G.mergeEdge(4, 3);
@@ -45,7 +45,7 @@ function prepareGraphG() {
 }
 
 function prepareGraphH() {
-  const H = new graphology.Graph();
+  const H = new graphology.UndirectedGraph();
   H.addNode(0);
   H.mergeEdge(1, 3);
   H.mergeEdge(3, 6);
@@ -58,7 +58,7 @@ function prepareGraphH() {
 }
 
 function prepareCycle() {
-  const G = new graphology.Graph();
+  const G = new graphology.UndirectedGraph();
   G.mergeEdge(1, 2);
   G.mergeEdge(2, 3);
   G.mergeEdge(3, 1);
@@ -74,6 +74,14 @@ function prepareDiGraphI() {
   I.mergeEdge(3, 4);
   I.mergeEdge(4, 3);
   return I;
+}
+
+function range(s, e) {
+  const set = new Set();
+  for (let i = s; i < e; ++i) {
+    set.add(i);
+  }
+  return set;
 }
 
 describe('Core', function () {
@@ -207,7 +215,7 @@ describe('Core', function () {
     assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
   });
 
-  it('should return the subgraph of any k shell', function () {
+  it('should return the subgraph of any k shell.', function () {
     let graph = prepareGraphH();
     let subgraph = core.kShell(graph, 0);
     let nodes = subgraph.mapNodes(a => a);
@@ -224,7 +232,7 @@ describe('Core', function () {
     assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
   });
 
-  it('should return the subgraph of any k corona', function () {
+  it('should return the subgraph of any k corona.', function () {
     let graph = prepareGraphH();
     let subgraph = core.kCorona(graph, 0);
     let nodes = subgraph.mapNodes(a => a);
@@ -239,6 +247,60 @@ describe('Core', function () {
     subgraph = core.kCorona(graph, 2);
     nodes = subgraph.mapNodes(a => a);
     assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+  });
+
+  it('should return the subgraph of any k truss.', function () {
+    const graph = prepareGraphG();
+
+    let subgraph = undefined;
+    let nodes = undefined;
+
+    subgraph = core.kTruss(graph, -1);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), range(1, 21));
+
+    subgraph = core.kTruss(graph, 0);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), range(1, 21));
+
+    subgraph = core.kTruss(graph, 1);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), range(1, 21));
+
+    subgraph = core.kTruss(graph, 2);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), range(1, 21));
+
+    subgraph = core.kTruss(graph, 3);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), range(1, 13));
+
+    subgraph = core.kTruss(graph, 4);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), range(1, 9));
+
+    subgraph = core.kTruss(graph, 5);
+    nodes = subgraph.nodes();
+    assert.deepEqual(new Set(nodes), new Set());
+  });
+
+  it('should not return k truss if k is null.', function () {
+    const graph = prepareGraphG();
+    assert.throws(function () {
+      core.kTruss(graph);
+    }, /graphology/);
+  });
+
+  it('should not return k truss if the graph is directed or multigraph.', function () {
+    const graphA = new graphology.DirectedGraph();
+    assert.throws(function () {
+      core.kTruss(graphA);
+    }, /graphology/);
+
+    const graphB = new graphology.MultiGraph();
+    assert.throws(function () {
+      core.kTruss(graphB);
+    }, /graphology/);
   });
 
   it('should not calculate onion layers if the graph is directed.', function () {

--- a/src/cores/test.js
+++ b/src/cores/test.js
@@ -1,0 +1,310 @@
+const graphology = require('graphology');
+const core = require('./index');
+const assert = require('assert');
+
+function prepareGraphG() {
+    const G = new graphology.Graph();
+    G.mergeEdge(4, 1);
+    G.mergeEdge(4, 2);
+    G.mergeEdge(4, 3);
+    G.mergeEdge(1, 2);
+    G.mergeEdge(2, 3);
+    G.mergeEdge(3, 1);
+
+    G.mergeEdge(8, 5);
+    G.mergeEdge(8, 6);
+    G.mergeEdge(8, 7);
+    G.mergeEdge(5, 6);
+    G.mergeEdge(6, 7);
+    G.mergeEdge(7, 5);
+
+    G.mergeEdge(2, 11);
+    G.mergeEdge(11, 5);
+
+    G.mergeEdge(12, 5);
+    G.mergeEdge(12, 11);
+    G.mergeEdge(12, 18);
+    G.mergeEdge(12, 19);
+
+    G.mergeEdge(3, 7);
+    G.mergeEdge(3, 9);
+    G.mergeEdge(7, 9);
+    G.mergeEdge(7, 10);
+    G.mergeEdge(9, 10);
+    G.mergeEdge(9, 20);
+
+    G.mergeEdge(17, 13);
+    G.mergeEdge(13, 14);
+    G.mergeEdge(14, 15);
+    G.mergeEdge(15, 16);
+    G.mergeEdge(16, 13);
+
+    G.addNode(21);
+
+    return G
+}
+
+function prepareGraphH() {
+    const H = new graphology.Graph();
+    H.addNode(0);
+    H.mergeEdge(1, 3);
+    H.mergeEdge(3, 6);
+    H.mergeEdge(6, 4);
+    H.mergeEdge(6, 5);
+    H.mergeEdge(4, 2);
+    H.mergeEdge(5, 2);
+
+    return H;
+}
+
+function prepareCycle() {
+    const G = new graphology.Graph();
+    G.mergeEdge(1, 2);
+    G.mergeEdge(2, 3);
+    G.mergeEdge(3, 1);
+    return G;
+}
+
+function prepareDiGraphI() {
+    const I = new graphology.DirectedGraph();
+    I.mergeEdge(1, 2);
+    I.mergeEdge(2, 1);
+    I.mergeEdge(2, 3);
+    I.mergeEdge(2, 4);
+    I.mergeEdge(3, 4);
+    I.mergeEdge(4, 3);
+    return I;
+}
+
+describe("Core", function () {
+
+    it("should work on empty graph.", function() {
+        const empty = new graphology.Graph();
+        const coreNumber = core.coreNumber(empty);
+        assert.deepEqual(coreNumber, {});
+    });
+
+    it("should return good nodes by core.", function () {
+        const graph = prepareGraphG();
+        const coreNumber = core.coreNumber(graph);
+        const byCores = Object.entries(coreNumber).reduce((obj, entry) => {
+            const [k, v] = entry;
+            if (obj[v] === undefined) obj[v] = new Set();
+            obj[v].add(k);
+            return obj;
+        }, {});
+
+        assert.deepEqual(byCores[0], new Set([21]));
+        assert.deepEqual(byCores[1], new Set([17, 18, 19, 20]));
+        assert.deepEqual(byCores[2], new Set([9, 10, 11, 12, 13, 14, 15, 16]));
+        assert.deepEqual(byCores[3], new Set([1, 2, 3, 4, 5, 6, 7, 8]));
+    });
+
+    it("should return good nodes by core again.", function () {
+        const graph = prepareGraphH();
+        const coreNumber = core.coreNumber(graph);
+        const byCores = Object.entries(coreNumber).reduce(function (obj, entry) {
+            const [k, v] = entry;
+            if (obj[v] === undefined) obj[v] = new Set();
+            obj[v].add(k);
+            return obj;
+        }, {});
+
+        assert.deepEqual(byCores[0], new Set([0]));
+        assert.deepEqual(byCores[1], new Set([1, 3]));
+        assert.deepEqual(byCores[2], new Set([2, 4, 5, 6]));
+    });
+
+    it("should not work if the grah has self loops.", function () {
+        const graph = prepareCycle();
+        graph.mergeEdge(1, 1);
+        assert.throws(function () {
+            core.coreNumber(graph);
+          }, /graphology/);
+    });
+
+    it("should return good nodes by core with directed graph.", function () {
+        const graph = prepareDiGraphI();
+        let coreNumber = core.coreNumber(graph);
+
+        assert.deepEqual(coreNumber, {
+            '1': 2,
+            '2': 2,
+            '3': 2,
+            '4': 2
+        });
+
+        // More edges
+        graph.mergeEdge(1, 5);
+        graph.mergeEdge(3, 5);
+        graph.mergeEdge(4, 5);
+        graph.mergeEdge(3, 6);
+        graph.mergeEdge(4, 6);
+        graph.mergeEdge(5, 6);
+        coreNumber = core.coreNumber(graph);
+
+        assert.deepEqual(coreNumber, {
+            '1': 3,
+            '2': 3,
+            '3': 3,
+            '4': 3,
+            '5': 3,
+            '6': 3
+        })
+    });
+
+    it('should return the subgrah of the main core.', function () {
+        const graph = prepareGraphH();
+        const subgraph = core.kCore(graph);
+        const nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            2, 4, 5, 6
+        ]));
+    });
+
+    it('should return the subgraph of any k core.', function () {
+        let graph = prepareGraphH();
+        let subgraph = core.kCore(graph, 0);
+        let nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set(graph.mapNodes(a => a)));
+
+        graph = prepareGraphH();
+        subgraph = core.kCore(graph, 1);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            1, 2, 3, 4, 5, 6
+        ]));
+
+        graph = prepareGraphH();
+        subgraph = core.kCore(graph, 2);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            2, 4, 5, 6
+        ]));
+    });
+
+    it('should return the subgraph of the main crust.', function () {
+        const graph = prepareGraphH();
+        const subgraph = core.kCrust(graph);
+        const nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            0, 1, 3
+        ]));
+    });
+
+    it('should return the subgraph of any k crust.', function () {
+        let graph = prepareGraphH();
+        let subgraph = core.kCrust(graph, 0);
+        let nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([0]));
+
+        graph = prepareGraphH();
+        subgraph = core.kCrust(graph, 1);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            0, 1, 3
+        ]));
+
+        graph = prepareGraphH();
+        subgraph = core.kCrust(graph, 2);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set(graph.mapNodes(a => a)));
+
+    });
+
+    it('should return the subgraph of the main shell.', function () {
+        const graph = prepareGraphH();
+        const subgraph = core.kShell(graph);
+        const nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+    });
+
+    it('should return the subgraph of any k shell', function() {
+        let graph = prepareGraphH();
+        let subgraph = core.kShell(graph, 0);
+        let nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([0]));
+
+        graph = prepareGraphH();
+        subgraph = core.kShell(graph, 1);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            1, 3
+        ]));
+
+        graph = prepareGraphH();
+        subgraph = core.kShell(graph, 2);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes),  new Set([
+            2, 4, 5, 6
+        ]));
+    });
+
+    it('should return the subgraph of any k corona', function() {
+        let graph = prepareGraphH();
+        let subgraph = core.kCorona(graph, 0);
+        let nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([0]));
+
+        graph = prepareGraphH();
+        subgraph = core.kCorona(graph, 1);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes), new Set([
+            1
+        ]));
+
+        graph = prepareGraphH();
+        subgraph = core.kCorona(graph, 2);
+        nodes = subgraph.mapNodes(a => a);
+        assert.deepEqual(new Set(nodes),  new Set([
+            2, 4, 5, 6
+        ]));
+    });
+
+    it('should not calculate onion layers if the graph is directed.', function() {
+        const graph = prepareDiGraphI();
+        assert.throws(function () {
+            core.onionLayers(graph);
+          }, /graphology/);
+    });
+
+    it('should return good onion layers.', function () {
+        const graph = prepareGraphG();
+        const onion = core.onionLayers(graph);
+        const nodesByLayer = [];
+        for (let i = 1; i < 7; ++i) {
+            const layer = new Set();
+            Object.keys(onion).forEach(node => {
+                if (onion[node] === i) layer.add(node);
+            });
+            nodesByLayer.push(layer);
+        }
+
+        assert.deepEqual(nodesByLayer[0], new Set([21]));
+        assert.deepEqual(nodesByLayer[1], new Set([17, 18, 19, 20]));
+        assert.deepEqual(nodesByLayer[2], new Set([10, 12, 13, 14, 15, 16]));
+        assert.deepEqual(nodesByLayer[3], new Set([9, 11]));
+        assert.deepEqual(nodesByLayer[4], new Set([1, 2, 4, 5, 6, 8]));
+        assert.deepEqual(nodesByLayer[5], new Set([3, 7]));
+    });
+
+    it('should assign onion layers for each node.', function () {
+        const graph = prepareGraphG();
+        const onion = core.onionLayers.assign(graph, "onion");
+
+        graph.forEachNode(node => {
+            const layer = graph.getNodeAttribute(node, "onion");
+            assert.equal(layer, onion[node]);
+        })
+    });
+
+    it('should assign core for each node.', function () {
+        const graph = prepareGraphG();
+        const degen = core.coreNumber.assign(graph, "core");
+
+        graph.forEachNode(node => {
+            const layer = graph.getNodeAttribute(node, "core");
+            assert.equal(layer, degen[node]);
+        })
+    });
+});

--- a/src/cores/test.js
+++ b/src/cores/test.js
@@ -3,308 +3,288 @@ const core = require('./index');
 const assert = require('assert');
 
 function prepareGraphG() {
-    const G = new graphology.Graph();
-    G.mergeEdge(4, 1);
-    G.mergeEdge(4, 2);
-    G.mergeEdge(4, 3);
-    G.mergeEdge(1, 2);
-    G.mergeEdge(2, 3);
-    G.mergeEdge(3, 1);
+  const G = new graphology.Graph();
+  G.mergeEdge(4, 1);
+  G.mergeEdge(4, 2);
+  G.mergeEdge(4, 3);
+  G.mergeEdge(1, 2);
+  G.mergeEdge(2, 3);
+  G.mergeEdge(3, 1);
 
-    G.mergeEdge(8, 5);
-    G.mergeEdge(8, 6);
-    G.mergeEdge(8, 7);
-    G.mergeEdge(5, 6);
-    G.mergeEdge(6, 7);
-    G.mergeEdge(7, 5);
+  G.mergeEdge(8, 5);
+  G.mergeEdge(8, 6);
+  G.mergeEdge(8, 7);
+  G.mergeEdge(5, 6);
+  G.mergeEdge(6, 7);
+  G.mergeEdge(7, 5);
 
-    G.mergeEdge(2, 11);
-    G.mergeEdge(11, 5);
+  G.mergeEdge(2, 11);
+  G.mergeEdge(11, 5);
 
-    G.mergeEdge(12, 5);
-    G.mergeEdge(12, 11);
-    G.mergeEdge(12, 18);
-    G.mergeEdge(12, 19);
+  G.mergeEdge(12, 5);
+  G.mergeEdge(12, 11);
+  G.mergeEdge(12, 18);
+  G.mergeEdge(12, 19);
 
-    G.mergeEdge(3, 7);
-    G.mergeEdge(3, 9);
-    G.mergeEdge(7, 9);
-    G.mergeEdge(7, 10);
-    G.mergeEdge(9, 10);
-    G.mergeEdge(9, 20);
+  G.mergeEdge(3, 7);
+  G.mergeEdge(3, 9);
+  G.mergeEdge(7, 9);
+  G.mergeEdge(7, 10);
+  G.mergeEdge(9, 10);
+  G.mergeEdge(9, 20);
 
-    G.mergeEdge(17, 13);
-    G.mergeEdge(13, 14);
-    G.mergeEdge(14, 15);
-    G.mergeEdge(15, 16);
-    G.mergeEdge(16, 13);
+  G.mergeEdge(17, 13);
+  G.mergeEdge(13, 14);
+  G.mergeEdge(14, 15);
+  G.mergeEdge(15, 16);
+  G.mergeEdge(16, 13);
 
-    G.addNode(21);
+  G.addNode(21);
 
-    return G
+  return G;
 }
 
 function prepareGraphH() {
-    const H = new graphology.Graph();
-    H.addNode(0);
-    H.mergeEdge(1, 3);
-    H.mergeEdge(3, 6);
-    H.mergeEdge(6, 4);
-    H.mergeEdge(6, 5);
-    H.mergeEdge(4, 2);
-    H.mergeEdge(5, 2);
+  const H = new graphology.Graph();
+  H.addNode(0);
+  H.mergeEdge(1, 3);
+  H.mergeEdge(3, 6);
+  H.mergeEdge(6, 4);
+  H.mergeEdge(6, 5);
+  H.mergeEdge(4, 2);
+  H.mergeEdge(5, 2);
 
-    return H;
+  return H;
 }
 
 function prepareCycle() {
-    const G = new graphology.Graph();
-    G.mergeEdge(1, 2);
-    G.mergeEdge(2, 3);
-    G.mergeEdge(3, 1);
-    return G;
+  const G = new graphology.Graph();
+  G.mergeEdge(1, 2);
+  G.mergeEdge(2, 3);
+  G.mergeEdge(3, 1);
+  return G;
 }
 
 function prepareDiGraphI() {
-    const I = new graphology.DirectedGraph();
-    I.mergeEdge(1, 2);
-    I.mergeEdge(2, 1);
-    I.mergeEdge(2, 3);
-    I.mergeEdge(2, 4);
-    I.mergeEdge(3, 4);
-    I.mergeEdge(4, 3);
-    return I;
+  const I = new graphology.DirectedGraph();
+  I.mergeEdge(1, 2);
+  I.mergeEdge(2, 1);
+  I.mergeEdge(2, 3);
+  I.mergeEdge(2, 4);
+  I.mergeEdge(3, 4);
+  I.mergeEdge(4, 3);
+  return I;
 }
 
-describe("Core", function () {
+describe('Core', function () {
+  it('should work on empty graph.', function () {
+    const empty = new graphology.Graph();
+    const coreNumber = core.coreNumber(empty);
+    assert.deepEqual(coreNumber, {});
+  });
 
-    it("should work on empty graph.", function() {
-        const empty = new graphology.Graph();
-        const coreNumber = core.coreNumber(empty);
-        assert.deepEqual(coreNumber, {});
+  it('should return good nodes by core.', function () {
+    const graph = prepareGraphG();
+    const coreNumber = core.coreNumber(graph);
+    const byCores = Object.entries(coreNumber).reduce((obj, entry) => {
+      const [k, v] = entry;
+      if (obj[v] === undefined) obj[v] = new Set();
+      obj[v].add(k);
+      return obj;
+    }, {});
+
+    assert.deepEqual(byCores[0], new Set([21]));
+    assert.deepEqual(byCores[1], new Set([17, 18, 19, 20]));
+    assert.deepEqual(byCores[2], new Set([9, 10, 11, 12, 13, 14, 15, 16]));
+    assert.deepEqual(byCores[3], new Set([1, 2, 3, 4, 5, 6, 7, 8]));
+  });
+
+  it('should return good nodes by core again.', function () {
+    const graph = prepareGraphH();
+    const coreNumber = core.coreNumber(graph);
+    const byCores = Object.entries(coreNumber).reduce(function (obj, entry) {
+      const [k, v] = entry;
+      if (obj[v] === undefined) obj[v] = new Set();
+      obj[v].add(k);
+      return obj;
+    }, {});
+
+    assert.deepEqual(byCores[0], new Set([0]));
+    assert.deepEqual(byCores[1], new Set([1, 3]));
+    assert.deepEqual(byCores[2], new Set([2, 4, 5, 6]));
+  });
+
+  it('should not work if the grah has self loops.', function () {
+    const graph = prepareCycle();
+    graph.mergeEdge(1, 1);
+    assert.throws(function () {
+      core.coreNumber(graph);
+    }, /graphology/);
+  });
+
+  it('should return good nodes by core with directed graph.', function () {
+    const graph = prepareDiGraphI();
+    let coreNumber = core.coreNumber(graph);
+
+    assert.deepEqual(coreNumber, {
+      1: 2,
+      2: 2,
+      3: 2,
+      4: 2
     });
 
-    it("should return good nodes by core.", function () {
-        const graph = prepareGraphG();
-        const coreNumber = core.coreNumber(graph);
-        const byCores = Object.entries(coreNumber).reduce((obj, entry) => {
-            const [k, v] = entry;
-            if (obj[v] === undefined) obj[v] = new Set();
-            obj[v].add(k);
-            return obj;
-        }, {});
+    // More edges
+    graph.mergeEdge(1, 5);
+    graph.mergeEdge(3, 5);
+    graph.mergeEdge(4, 5);
+    graph.mergeEdge(3, 6);
+    graph.mergeEdge(4, 6);
+    graph.mergeEdge(5, 6);
+    coreNumber = core.coreNumber(graph);
 
-        assert.deepEqual(byCores[0], new Set([21]));
-        assert.deepEqual(byCores[1], new Set([17, 18, 19, 20]));
-        assert.deepEqual(byCores[2], new Set([9, 10, 11, 12, 13, 14, 15, 16]));
-        assert.deepEqual(byCores[3], new Set([1, 2, 3, 4, 5, 6, 7, 8]));
+    assert.deepEqual(coreNumber, {
+      1: 3,
+      2: 3,
+      3: 3,
+      4: 3,
+      5: 3,
+      6: 3
     });
+  });
 
-    it("should return good nodes by core again.", function () {
-        const graph = prepareGraphH();
-        const coreNumber = core.coreNumber(graph);
-        const byCores = Object.entries(coreNumber).reduce(function (obj, entry) {
-            const [k, v] = entry;
-            if (obj[v] === undefined) obj[v] = new Set();
-            obj[v].add(k);
-            return obj;
-        }, {});
+  it('should return the subgrah of the main core.', function () {
+    const graph = prepareGraphH();
+    const subgraph = core.kCore(graph);
+    const nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+  });
 
-        assert.deepEqual(byCores[0], new Set([0]));
-        assert.deepEqual(byCores[1], new Set([1, 3]));
-        assert.deepEqual(byCores[2], new Set([2, 4, 5, 6]));
+  it('should return the subgraph of any k core.', function () {
+    let graph = prepareGraphH();
+    let subgraph = core.kCore(graph, 0);
+    let nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set(graph.mapNodes(a => a)));
+
+    graph = prepareGraphH();
+    subgraph = core.kCore(graph, 1);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([1, 2, 3, 4, 5, 6]));
+
+    graph = prepareGraphH();
+    subgraph = core.kCore(graph, 2);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+  });
+
+  it('should return the subgraph of the main crust.', function () {
+    const graph = prepareGraphH();
+    const subgraph = core.kCrust(graph);
+    const nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([0, 1, 3]));
+  });
+
+  it('should return the subgraph of any k crust.', function () {
+    let graph = prepareGraphH();
+    let subgraph = core.kCrust(graph, 0);
+    let nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([0]));
+
+    graph = prepareGraphH();
+    subgraph = core.kCrust(graph, 1);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([0, 1, 3]));
+
+    graph = prepareGraphH();
+    subgraph = core.kCrust(graph, 2);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set(graph.mapNodes(a => a)));
+  });
+
+  it('should return the subgraph of the main shell.', function () {
+    const graph = prepareGraphH();
+    const subgraph = core.kShell(graph);
+    const nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+  });
+
+  it('should return the subgraph of any k shell', function () {
+    let graph = prepareGraphH();
+    let subgraph = core.kShell(graph, 0);
+    let nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([0]));
+
+    graph = prepareGraphH();
+    subgraph = core.kShell(graph, 1);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([1, 3]));
+
+    graph = prepareGraphH();
+    subgraph = core.kShell(graph, 2);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+  });
+
+  it('should return the subgraph of any k corona', function () {
+    let graph = prepareGraphH();
+    let subgraph = core.kCorona(graph, 0);
+    let nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([0]));
+
+    graph = prepareGraphH();
+    subgraph = core.kCorona(graph, 1);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([1]));
+
+    graph = prepareGraphH();
+    subgraph = core.kCorona(graph, 2);
+    nodes = subgraph.mapNodes(a => a);
+    assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
+  });
+
+  it('should not calculate onion layers if the graph is directed.', function () {
+    const graph = prepareDiGraphI();
+    assert.throws(function () {
+      core.onionLayers(graph);
+    }, /graphology/);
+  });
+
+  it('should return good onion layers.', function () {
+    const graph = prepareGraphG();
+    const onion = core.onionLayers(graph);
+    const nodesByLayer = [];
+    for (let i = 1; i < 7; ++i) {
+      const layer = new Set();
+      Object.keys(onion).forEach(node => {
+        if (onion[node] === i) layer.add(node);
+      });
+      nodesByLayer.push(layer);
+    }
+
+    assert.deepEqual(nodesByLayer[0], new Set([21]));
+    assert.deepEqual(nodesByLayer[1], new Set([17, 18, 19, 20]));
+    assert.deepEqual(nodesByLayer[2], new Set([10, 12, 13, 14, 15, 16]));
+    assert.deepEqual(nodesByLayer[3], new Set([9, 11]));
+    assert.deepEqual(nodesByLayer[4], new Set([1, 2, 4, 5, 6, 8]));
+    assert.deepEqual(nodesByLayer[5], new Set([3, 7]));
+  });
+
+  it('should assign onion layers for each node.', function () {
+    const graph = prepareGraphG();
+    const onion = core.onionLayers.assign(graph, 'onion');
+
+    graph.forEachNode(node => {
+      const layer = graph.getNodeAttribute(node, 'onion');
+      assert.equal(layer, onion[node]);
     });
+  });
 
-    it("should not work if the grah has self loops.", function () {
-        const graph = prepareCycle();
-        graph.mergeEdge(1, 1);
-        assert.throws(function () {
-            core.coreNumber(graph);
-          }, /graphology/);
+  it('should assign core for each node.', function () {
+    const graph = prepareGraphG();
+    const degen = core.coreNumber.assign(graph, 'core');
+
+    graph.forEachNode(node => {
+      const layer = graph.getNodeAttribute(node, 'core');
+      assert.equal(layer, degen[node]);
     });
-
-    it("should return good nodes by core with directed graph.", function () {
-        const graph = prepareDiGraphI();
-        let coreNumber = core.coreNumber(graph);
-
-        assert.deepEqual(coreNumber, {
-            '1': 2,
-            '2': 2,
-            '3': 2,
-            '4': 2
-        });
-
-        // More edges
-        graph.mergeEdge(1, 5);
-        graph.mergeEdge(3, 5);
-        graph.mergeEdge(4, 5);
-        graph.mergeEdge(3, 6);
-        graph.mergeEdge(4, 6);
-        graph.mergeEdge(5, 6);
-        coreNumber = core.coreNumber(graph);
-
-        assert.deepEqual(coreNumber, {
-            '1': 3,
-            '2': 3,
-            '3': 3,
-            '4': 3,
-            '5': 3,
-            '6': 3
-        })
-    });
-
-    it('should return the subgrah of the main core.', function () {
-        const graph = prepareGraphH();
-        const subgraph = core.kCore(graph);
-        const nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            2, 4, 5, 6
-        ]));
-    });
-
-    it('should return the subgraph of any k core.', function () {
-        let graph = prepareGraphH();
-        let subgraph = core.kCore(graph, 0);
-        let nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set(graph.mapNodes(a => a)));
-
-        graph = prepareGraphH();
-        subgraph = core.kCore(graph, 1);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            1, 2, 3, 4, 5, 6
-        ]));
-
-        graph = prepareGraphH();
-        subgraph = core.kCore(graph, 2);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            2, 4, 5, 6
-        ]));
-    });
-
-    it('should return the subgraph of the main crust.', function () {
-        const graph = prepareGraphH();
-        const subgraph = core.kCrust(graph);
-        const nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            0, 1, 3
-        ]));
-    });
-
-    it('should return the subgraph of any k crust.', function () {
-        let graph = prepareGraphH();
-        let subgraph = core.kCrust(graph, 0);
-        let nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([0]));
-
-        graph = prepareGraphH();
-        subgraph = core.kCrust(graph, 1);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            0, 1, 3
-        ]));
-
-        graph = prepareGraphH();
-        subgraph = core.kCrust(graph, 2);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set(graph.mapNodes(a => a)));
-
-    });
-
-    it('should return the subgraph of the main shell.', function () {
-        const graph = prepareGraphH();
-        const subgraph = core.kShell(graph);
-        const nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([2, 4, 5, 6]));
-    });
-
-    it('should return the subgraph of any k shell', function() {
-        let graph = prepareGraphH();
-        let subgraph = core.kShell(graph, 0);
-        let nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([0]));
-
-        graph = prepareGraphH();
-        subgraph = core.kShell(graph, 1);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            1, 3
-        ]));
-
-        graph = prepareGraphH();
-        subgraph = core.kShell(graph, 2);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes),  new Set([
-            2, 4, 5, 6
-        ]));
-    });
-
-    it('should return the subgraph of any k corona', function() {
-        let graph = prepareGraphH();
-        let subgraph = core.kCorona(graph, 0);
-        let nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([0]));
-
-        graph = prepareGraphH();
-        subgraph = core.kCorona(graph, 1);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes), new Set([
-            1
-        ]));
-
-        graph = prepareGraphH();
-        subgraph = core.kCorona(graph, 2);
-        nodes = subgraph.mapNodes(a => a);
-        assert.deepEqual(new Set(nodes),  new Set([
-            2, 4, 5, 6
-        ]));
-    });
-
-    it('should not calculate onion layers if the graph is directed.', function() {
-        const graph = prepareDiGraphI();
-        assert.throws(function () {
-            core.onionLayers(graph);
-          }, /graphology/);
-    });
-
-    it('should return good onion layers.', function () {
-        const graph = prepareGraphG();
-        const onion = core.onionLayers(graph);
-        const nodesByLayer = [];
-        for (let i = 1; i < 7; ++i) {
-            const layer = new Set();
-            Object.keys(onion).forEach(node => {
-                if (onion[node] === i) layer.add(node);
-            });
-            nodesByLayer.push(layer);
-        }
-
-        assert.deepEqual(nodesByLayer[0], new Set([21]));
-        assert.deepEqual(nodesByLayer[1], new Set([17, 18, 19, 20]));
-        assert.deepEqual(nodesByLayer[2], new Set([10, 12, 13, 14, 15, 16]));
-        assert.deepEqual(nodesByLayer[3], new Set([9, 11]));
-        assert.deepEqual(nodesByLayer[4], new Set([1, 2, 4, 5, 6, 8]));
-        assert.deepEqual(nodesByLayer[5], new Set([3, 7]));
-    });
-
-    it('should assign onion layers for each node.', function () {
-        const graph = prepareGraphG();
-        const onion = core.onionLayers.assign(graph, "onion");
-
-        graph.forEachNode(node => {
-            const layer = graph.getNodeAttribute(node, "onion");
-            assert.equal(layer, onion[node]);
-        })
-    });
-
-    it('should assign core for each node.', function () {
-        const graph = prepareGraphG();
-        const degen = core.coreNumber.assign(graph, "core");
-
-        graph.forEachNode(node => {
-            const layer = graph.getNodeAttribute(node, "core");
-            assert.equal(layer, degen[node]);
-        })
-    });
+  });
 });


### PR DESCRIPTION
Implementation of the degeneracy calculation already available in the `networkx` python library. It adds to graphology the following methods : 

* coreNumber()
* kCore()
* kShell()
* kCrust()
* kCorona()
* onionLayers()

However, it doesn't include the method `kTruss()`.

The pull request includes tests, a package description and a readme documentation. 

The typescript description file `index.d.ts` needs to be written.

For more details of the original python implementation : [https://networkx.org/documentation/stable/reference/algorithms/core.html](https://networkx.org/documentation/stable/reference/algorithms/core.html)