### PR TITLE
Fix graphology declaration file export

### DIFF
--- a/src/graphology/package.json
+++ b/src/graphology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphology",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "A robust and multipurpose Graph object for JavaScript.",
   "main": "dist/graphology.cjs.js",
   "module": "dist/graphology.esm.js",

--- a/src/graphology/package.json
+++ b/src/graphology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphology",
-  "version": "0.25.3",
+  "version": "0.25.2",
   "description": "A robust and multipurpose Graph object for JavaScript.",
   "main": "dist/graphology.cjs.js",
   "module": "dist/graphology.esm.js",

--- a/src/graphology/package.json
+++ b/src/graphology/package.json
@@ -5,6 +5,7 @@
   "main": "dist/graphology.cjs.js",
   "module": "dist/graphology.esm.js",
   "browser": "dist/graphology.umd.min.js",
+  "types": "dist/graphology.d.ts",
   "exports": {
     "require": "./dist/graphology.cjs.js",
     "import": "./dist/graphology.mjs",

--- a/src/graphology/package.json
+++ b/src/graphology/package.json
@@ -5,10 +5,10 @@
   "main": "dist/graphology.cjs.js",
   "module": "dist/graphology.esm.js",
   "browser": "dist/graphology.umd.min.js",
-  "types": "dist/graphology.d.ts",
   "exports": {
     "require": "./dist/graphology.cjs.js",
-    "import": "./dist/graphology.mjs"
+    "import": "./dist/graphology.mjs",
+    "types": "./dist/graphology.d.ts"
   },
   "scripts": {
     "clean": "rimraf dist specs",


### PR DESCRIPTION
Fixed this error:

> There are types at 'my-project/node_modules/graphology/dist/graphology.d.ts', but this result could not be resolved when respecting package.json "exports". The 'graphology' library may need to update its package.json or typings.