### PR TITLE
[dag] Fix type of topologicalGenerations

### DIFF
--- a/src/dag/topological-sort.d.ts
+++ b/src/dag/topological-sort.d.ts
@@ -17,4 +17,4 @@ export function forEachTopologicalGeneration<
   graph: Graph<NodeAttributes>,
   callback: (generation: Array<string>) => void
 ): void;
-export function topologicalGenerations(graph: Graph): Array<string>;
+export function topologicalGenerations(graph: Graph): Array<Array<string>>;


### PR DESCRIPTION
topologicalGenerations returns an array of arrays of strings (node names), not a single-level array.