### PR TITLE
Remove Lodash use from canvas

### DIFF
--- a/src/canvas/defaults.js
+++ b/src/canvas/defaults.js
@@ -1,4 +1,4 @@
-var merge = require('lodash/merge');
+var resolveDefaults = require('graphology-utils/defaults');
 
 var DEFAULTS = {
   batchSize: 500,
@@ -31,7 +31,8 @@ exports.refineSettings = function refineSettings(settings) {
   if (dimensions.height && !dimensions.width)
     dimensions.width = dimensions.height;
 
-  settings = merge({}, DEFAULTS, settings, dimensions);
+  settings = resolveDefaults(settings, dimensions);
+  settings = resolveDefaults(settings, DEFAULTS);
 
   if (!settings.width && !settings.height)
     throw new Error(


### PR DESCRIPTION
`graphology-canvas` has an undeclared dependency on `lodash/merge`. I'm using it in a Vite project and had to add `lodash` to my `package.json` to get the build working. I see `lodash` was mostly dropped in https://github.com/graphology/graphology/commit/0501a36848d87425345a10e15a7f60b6c4db0fd0, so I think this was left like this by accident.

The tests passed locally.