### PR TITLE
[gexf] serialize Sets as Lists

### DIFF
--- a/src/gexf/common/writer.js
+++ b/src/gexf/common/writer.js
@@ -188,8 +188,8 @@ function inferListValueType(values) {
 }
 
 function inferValueType(value) {
-  if (Array.isArray(value)) {
-    var type = inferListValueType(value);
+  if (Array.isArray(value) || value instanceof Set) {
+    var type = inferListValueType(Array.from(value));
 
     if (type === 'empty') return 'empty';
 
@@ -228,13 +228,14 @@ function serializeValue(type, value) {
  */
 function cast(version, type, value) {
   if (type.startsWith('list')) {
-    value = Array.isArray(value) ? value : [value];
+    var arrayValue = Array.isArray(value) ? value : [value];
+    if (value instanceof Set) arrayValue = Array.from(value);
 
     var subtype = type.slice(4);
     if (version === '1.3') {
       return (
         '[' +
-        value
+        arrayValue
           .map(function (v) {
             return serializeValue(subtype, v);
           })
@@ -242,7 +243,7 @@ function cast(version, type, value) {
         ']'
       );
     } else {
-      return value.join('|');
+      return arrayValue.join('|');
     }
   }
 

--- a/src/gexf/test/definitions/writer.js
+++ b/src/gexf/test/definitions/writer.js
@@ -49,6 +49,7 @@ var createBasicGraph = function () {
     thickness: 34,
     shape: 'dotted',
     label: 'Fine edge',
+    set: new Set(['truc', 'machin']),
     number: 12,
     useless: ''
   });
@@ -88,7 +89,8 @@ module.exports = [
           label: attributes.label ? '(Edge) - ' + attributes.label : '',
           weight: attributes.weight / 2,
           attributes: {
-            number: attributes.number
+            number: attributes.number,
+            set: attributes.set
           },
           viz: {
             shape: attributes.shape

--- a/src/gexf/test/resources/basic.gexf
+++ b/src/gexf/test/resources/basic.gexf
@@ -13,6 +13,7 @@
       <attribute id="mixed" title="mixed" type="string"/>
     </attributes>
     <attributes class="edge">
+      <attribute id="set" title="set" type="liststring"/>
       <attribute id="number" title="number" type="integer"/>
     </attributes>
     <nodes>
@@ -43,6 +44,7 @@
     <edges>
       <edge id="J-S" source="John" target="Suzy" weight="456" label="Fine edge">
         <attvalues>
+          <attvalue for="set" value="truc|machin"/>
           <attvalue for="number" value="12"/>
         </attvalues>
         <viz:color r="204" g="207" b="255"/>

--- a/src/gexf/test/resources/basic_formatted.gexf
+++ b/src/gexf/test/resources/basic_formatted.gexf
@@ -12,6 +12,7 @@
     </attributes>
     <attributes class="edge">
       <attribute id="number" title="number" type="integer"/>
+      <attribute id="set" title="set" type="liststring"/>
     </attributes>
     <nodes>
       <node id="Suzy" label="(Node) - Suzy, Ghost">
@@ -35,6 +36,7 @@
       <edge id="J-S" source="John" target="Suzy" weight="228" label="(Edge) - Fine edge">
         <attvalues>
           <attvalue for="number" value="12"/>
+          <attvalue for="set" value="truc|machin"/>
         </attvalues>
         <viz:shape value="dotted"/>
       </edge>


### PR DESCRIPTION
Currently JS Sets are serialized through JSON.stringify which outputs `[object Set]`.
This PR proposes to serialize Sets as the same way as Arrays.