### PR TITLE
Replace obliterator dependency with plain Iterator objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14297,8 +14297,7 @@
       "version": "0.25.4",
       "license": "MIT",
       "dependencies": {
-        "events": "^3.3.0",
-        "obliterator": "^2.0.2"
+        "events": "^3.3.0"
       },
       "peerDependencies": {
         "graphology-types": ">=0.24.0"

--- a/src/graphology/benchmark/object-iterator-items.js
+++ b/src/graphology/benchmark/object-iterator-items.js
@@ -1,41 +1,49 @@
 const randomString = require('pandemonium/random-string');
-const Iterator = require('obliterator/iterator');
-const consume = require('obliterator/consume');
 
 const N = 1000000;
 let i;
 
 const string = () => randomString(2, 15);
 
-const arrayItemsIterator = new Iterator(() => {
-  return {
-    done: false,
-    value: [
-      string(),
-      {name: string()},
-      string(),
-      string(),
-      {sourceData: string()},
-      {targetData: string()},
-      false
-    ]
-  };
-});
+const arrayItemsIterator = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    return {
+      done: false,
+      value: [
+        string(),
+        {name: string()},
+        string(),
+        string(),
+        {sourceData: string()},
+        {targetData: string()},
+        false
+      ]
+    };
+  }
+};
 
-const objectItemsIterator = new Iterator(() => {
-  return {
-    done: false,
-    value: {
-      key: string(),
-      attributes: {name: string()},
-      source: string(),
-      target: string(),
-      sourceAttributes: {sourceData: string()},
-      targetAttributes: {targetData: string()},
-      undirected: false
-    }
-  };
-});
+const objectItemsIterator = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    return {
+      done: false,
+      value: {
+        key: string(),
+        attributes: {name: string()},
+        source: string(),
+        target: string(),
+        sourceAttributes: {sourceData: string()},
+        targetAttributes: {targetData: string()},
+        undirected: false
+      }
+    };
+  }
+};
 
 const forEachWithArgs = (n, callback) => {
   for (let j = 0; j < n; j++)
@@ -64,11 +72,23 @@ const forEachWithObjects = (n, callback) => {
 };
 
 console.time('consume array');
-consume(arrayItemsIterator, N);
+i = 0;
+while (true) {
+  if (i === N) break;
+  const {done} = arrayItemsIterator.next();
+  if (done) break;
+  i++;
+}
 console.timeEnd('consume array');
 
 console.time('consume object');
-consume(objectItemsIterator, N);
+i = 0;
+while (true) {
+  if (i === N) break;
+  const {done} = objectItemsIterator.next();
+  if (done) break;
+  i++;
+}
 console.timeEnd('consume object');
 
 console.time('for of array');

--- a/src/graphology/package.json
+++ b/src/graphology/package.json
@@ -52,8 +52,7 @@
   },
   "homepage": "https://github.com/graphology/graphology#readme",
   "dependencies": {
-    "events": "^3.3.0",
-    "obliterator": "^2.0.2"
+    "events": "^3.3.0"
   },
   "peerDependencies": {
     "graphology-types": ">=0.24.0"
@@ -82,5 +81,10 @@
         }
       ]
     ]
+  },
+  "exports": {
+    "require": "./dist/graphology.cjs.js",
+    "import": "./dist/graphology.mjs",
+    "types": "./dist/graphology.d.ts"
   }
 }

--- a/src/graphology/rollup.config.js
+++ b/src/graphology/rollup.config.js
@@ -21,16 +21,7 @@ const bundle = (format, filename, options = {}) => ({
     sourcemap: true,
     exports: format === 'cjs' ? 'default' : undefined
   },
-  external: [
-    ...(!options.resolve
-      ? [
-          ...Object.keys(pkg.dependencies),
-          'obliterator/iterator',
-          'obliterator/take',
-          'obliterator/chain'
-        ]
-      : [])
-  ],
+  external: [...(!options.resolve ? Object.keys(pkg.dependencies) : [])],
   plugins: [
     ...(options.resolve ? [resolve({preferBuiltins: false}), commonjs()] : []),
     ...(options.babel ? [babel({exclude: 'node_modules/**'})] : []),

--- a/src/graphology/src/graph.js
+++ b/src/graphology/src/graph.js
@@ -6,8 +6,7 @@
  * Reference implementation of the graphology specs.
  */
 import {EventEmitter} from 'events';
-import Iterator from 'obliterator/iterator';
-import take from 'obliterator/take';
+import {take} from './utils';
 
 import {
   InvalidArgumentsGraphError,
@@ -2555,18 +2554,20 @@ export default class Graph extends EventEmitter {
   nodeEntries() {
     const iterator = this._nodes.values();
 
-    return new Iterator(() => {
-      const step = iterator.next();
-
-      if (step.done) return step;
-
-      const data = step.value;
-
-      return {
-        value: {node: data.key, attributes: data.attributes},
-        done: false
-      };
-    });
+    return {
+      [Symbol.iterator]() {
+        return this;
+      },
+      next() {
+        const step = iterator.next();
+        if (step.done) return step;
+        const data = step.value;
+        return {
+          value: {node: data.key, attributes: data.attributes},
+          done: false
+        };
+      }
+    };
   }
 
   /**---------------------------------------------------------------------------

--- a/src/graphology/src/iteration/edges.js
+++ b/src/graphology/src/iteration/edges.js
@@ -5,9 +5,8 @@
  * Attaching some methods to the Graph class to be able to iterate over a
  * graph's edges.
  */
-import Iterator from 'obliterator/iterator';
-import chain from 'obliterator/chain';
-import take from 'obliterator/take';
+import {chain, emptyIterator} from '../utils';
+import {take} from '../utils';
 
 import {InvalidArgumentsGraphError, NotFoundGraphError} from '../errors';
 
@@ -125,37 +124,42 @@ function createIterator(object, avoid) {
   let edgeData;
   let i = 0;
 
-  return new Iterator(function next() {
-    do {
-      if (!edgeData) {
-        if (i >= l) return {done: true};
+  return {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next() {
+      do {
+        if (!edgeData) {
+          if (i >= l) return {done: true};
 
-        const k = keys[i++];
+          const k = keys[i++];
 
-        if (k === avoid) {
-          edgeData = undefined;
-          continue;
+          if (k === avoid) {
+            edgeData = undefined;
+            continue;
+          }
+
+          edgeData = object[k];
+        } else {
+          edgeData = edgeData.next;
         }
+      } while (!edgeData);
 
-        edgeData = object[k];
-      } else {
-        edgeData = edgeData.next;
-      }
-    } while (!edgeData);
-
-    return {
-      done: false,
-      value: {
-        edge: edgeData.key,
-        attributes: edgeData.attributes,
-        source: edgeData.source.key,
-        target: edgeData.target.key,
-        sourceAttributes: edgeData.source.attributes,
-        targetAttributes: edgeData.target.attributes,
-        undirected: edgeData.undirected
-      }
-    };
-  });
+      return {
+        done: false,
+        value: {
+          edge: edgeData.key,
+          attributes: edgeData.attributes,
+          source: edgeData.source.key,
+          target: edgeData.target.key,
+          sourceAttributes: edgeData.source.attributes,
+          targetAttributes: edgeData.target.attributes,
+          undirected: edgeData.undirected
+        }
+      };
+    }
+  };
 }
 
 /**
@@ -226,37 +230,55 @@ function createIteratorForKey(object, k) {
   let edgeData = object[k];
 
   if (edgeData.next !== undefined) {
-    return new Iterator(function () {
-      if (!edgeData) return {done: true};
+    return {
+      [Symbol.iterator]() {
+        return this;
+      },
+      next() {
+        if (!edgeData) return {done: true};
 
-      const value = {
-        edge: edgeData.key,
-        attributes: edgeData.attributes,
-        source: edgeData.source.key,
-        target: edgeData.target.key,
-        sourceAttributes: edgeData.source.attributes,
-        targetAttributes: edgeData.target.attributes,
-        undirected: edgeData.undirected
-      };
+        const value = {
+          edge: edgeData.key,
+          attributes: edgeData.attributes,
+          source: edgeData.source.key,
+          target: edgeData.target.key,
+          sourceAttributes: edgeData.source.attributes,
+          targetAttributes: edgeData.target.attributes,
+          undirected: edgeData.undirected
+        };
 
-      edgeData = edgeData.next;
+        edgeData = edgeData.next;
 
-      return {
-        done: false,
-        value
-      };
-    });
+        return {
+          done: false,
+          value
+        };
+      }
+    };
   }
 
-  return Iterator.of({
-    edge: edgeData.key,
-    attributes: edgeData.attributes,
-    source: edgeData.source.key,
-    target: edgeData.target.key,
-    sourceAttributes: edgeData.source.attributes,
-    targetAttributes: edgeData.target.attributes,
-    undirected: edgeData.undirected
-  });
+  let done = false;
+  return {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next() {
+      if (done === true) return {done: true};
+      done = true;
+      return {
+        done: false,
+        value: {
+          edge: edgeData.key,
+          attributes: edgeData.attributes,
+          source: edgeData.source.key,
+          target: edgeData.target.key,
+          sourceAttributes: edgeData.source.attributes,
+          targetAttributes: edgeData.target.attributes,
+          undirected: edgeData.undirected
+        }
+      };
+    }
+  };
 }
 
 /**
@@ -345,41 +367,46 @@ function forEachEdge(breakable, graph, type, callback) {
  * @return {Iterator}
  */
 function createEdgeIterator(graph, type) {
-  if (graph.size === 0) return Iterator.empty();
+  if (graph.size === 0) return emptyIterator;
 
   const shouldFilter = type !== 'mixed' && type !== graph.type;
   const mask = type === 'undirected';
 
   const iterator = graph._edges.values();
 
-  return new Iterator(function next() {
-    let step, data;
+  return {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next() {
+      let step, data;
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      step = iterator.next();
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        step = iterator.next();
 
-      if (step.done) return step;
+        if (step.done) return step;
 
-      data = step.value;
+        data = step.value;
 
-      if (shouldFilter && data.undirected !== mask) continue;
+        if (shouldFilter && data.undirected !== mask) continue;
 
-      break;
+        break;
+      }
+
+      const value = {
+        edge: data.key,
+        attributes: data.attributes,
+        source: data.source.key,
+        target: data.target.key,
+        sourceAttributes: data.source.attributes,
+        targetAttributes: data.target.attributes,
+        undirected: data.undirected
+      };
+
+      return {value, done: false};
     }
-
-    const value = {
-      edge: data.key,
-      attributes: data.attributes,
-      source: data.source.key,
-      target: data.target.key,
-      sourceAttributes: data.source.attributes,
-      targetAttributes: data.target.attributes,
-      undirected: data.undirected
-    };
-
-    return {value, done: false};
-  });
+  };
 }
 
 /**
@@ -458,7 +485,7 @@ function createEdgeArrayForNode(multi, type, direction, nodeData) {
  * @return {Iterator}
  */
 function createEdgeIteratorForNode(type, direction, nodeData) {
-  let iterator = Iterator.empty();
+  let iterator = emptyIterator;
 
   if (type !== 'undirected') {
     if (direction !== 'out' && typeof nodeData.in !== 'undefined')
@@ -568,7 +595,7 @@ function createEdgeArrayForPath(type, multi, direction, sourceData, target) {
  * @param  {function} callback   - Function to call.
  */
 function createEdgeIteratorForPath(type, direction, sourceData, target) {
-  let iterator = Iterator.empty();
+  let iterator = emptyIterator;
 
   if (type !== 'undirected') {
     if (
@@ -1151,7 +1178,7 @@ function attachEdgeIteratorCreator(Class, description) {
   Class.prototype[name] = function (source, target) {
     // Early termination
     if (type !== 'mixed' && this.type !== 'mixed' && type !== this.type)
-      return Iterator.empty();
+      return emptyIterator;
 
     if (!arguments.length) return createEdgeIterator(this, type);
 

--- a/src/graphology/src/iteration/neighbors.js
+++ b/src/graphology/src/iteration/neighbors.js
@@ -5,8 +5,7 @@
  * Attaching some methods to the Graph class to be able to iterate over
  * neighbors.
  */
-import Iterator from 'obliterator/iterator';
-import chain from 'obliterator/chain';
+import {chain, emptyIterator} from '../utils';
 
 import {NotFoundGraphError, InvalidArgumentsGraphError} from '../errors';
 
@@ -19,7 +18,7 @@ const NEIGHBORS_ITERATION = [
     type: 'mixed'
   },
   {
-    name: 'inNeighbors',
+    /*  */ name: 'inNeighbors',
     type: 'directed',
     direction: 'in'
   },
@@ -206,33 +205,38 @@ function createDedupedObjectIterator(visited, nodeData, object) {
 
   let i = 0;
 
-  return new Iterator(function next() {
-    let neighborData = null;
+  return {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next() {
+      let neighborData = null;
 
-    do {
-      if (i >= l) {
-        if (visited) visited.wrap(object);
-        return {done: true};
-      }
+      do {
+        if (i >= l) {
+          if (visited) visited.wrap(object);
+          return {done: true};
+        }
 
-      const edgeData = object[keys[i++]];
+        const edgeData = object[keys[i++]];
 
-      const sourceData = edgeData.source;
-      const targetData = edgeData.target;
+        const sourceData = edgeData.source;
+        const targetData = edgeData.target;
 
-      neighborData = sourceData === nodeData ? targetData : sourceData;
+        neighborData = sourceData === nodeData ? targetData : sourceData;
 
-      if (visited && visited.has(neighborData.key)) {
-        neighborData = null;
-        continue;
-      }
-    } while (neighborData === null);
+        if (visited && visited.has(neighborData.key)) {
+          neighborData = null;
+          continue;
+        }
+      } while (neighborData === null);
 
-    return {
-      done: false,
-      value: {neighbor: neighborData.key, attributes: neighborData.attributes}
-    };
-  });
+      return {
+        done: false,
+        value: {neighbor: neighborData.key, attributes: neighborData.attributes}
+      };
+    }
+  };
 }
 
 function createNeighborIterator(type, direction, nodeData) {
@@ -245,7 +249,7 @@ function createNeighborIterator(type, direction, nodeData) {
       return createDedupedObjectIterator(null, nodeData, nodeData[direction]);
   }
 
-  let iterator = Iterator.empty();
+  let iterator = emptyIterator;
 
   // Else we need to keep a set of neighbors not to return duplicates
   // We cheat by querying the other adjacencies
@@ -537,7 +541,7 @@ function attachNeighborIteratorCreator(Class, description) {
   Class.prototype[iteratorName] = function (node) {
     // Early termination
     if (type !== 'mixed' && this.type !== 'mixed' && type !== this.type)
-      return Iterator.empty();
+      return emptyIterator;
 
     node = '' + node;
 

--- a/src/graphology/src/utils.js
+++ b/src/graphology/src/utils.js
@@ -155,3 +155,99 @@ export function incrementalIdStartingFromRandomByte() {
     return i++;
   };
 }
+
+/**
+ * Takes the first `n` items from the given iterable.
+ * @param {Iterable} iterable
+ * @param {number} n
+ * @returns {Array}
+ */
+export function take(iterable, n) {
+  let i = 0;
+
+  const iterator = iterable[Symbol.iterator]();
+
+  const array = new Array(n);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (i === n) return array;
+
+    const step = iterator.next();
+
+    if (step.done) {
+      if (i !== n) array.length = i;
+
+      return array;
+    }
+
+    array[i++] = step.value;
+  }
+}
+
+/**
+ * Chains multiple iterators into a single iterator.
+ *
+ * @param {...Iterator} iterables
+ * @returns {Iterator}
+ */
+export function chain() {
+  const iterables = arguments;
+  let current = null;
+  let i = -1;
+
+  return {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next() {
+      let step = null;
+
+      do {
+        if (current === null) {
+          i++;
+          if (i >= iterables.length) return {done: true};
+          current = iterables[i][Symbol.iterator]();
+        }
+        step = current.next();
+        if (step.done) {
+          current = null;
+          continue;
+        }
+        break;
+        // eslint-disable-next-line no-constant-condition
+      } while (true);
+
+      return step;
+    }
+  };
+}
+
+/**
+ * Maps the given iterable using the provided function.
+ *
+ * @param {Iterable} iterable
+ * @param {Function} fn
+ * @returns {Iterator}
+ */
+export function map(iterable, fn) {
+  return {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next() {
+      const step = iterable.next();
+      if (step.done) return step;
+      return {value: fn(step.value), done: false};
+    }
+  };
+}
+
+export const emptyIterator = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    return {done: true};
+  }
+};

--- a/src/graphology/tests/iteration/edges.js
+++ b/src/graphology/tests/iteration/edges.js
@@ -5,8 +5,7 @@
  * Testing the edges iteration-related methods of the graph.
  */
 import assert from 'assert';
-import take from 'obliterator/take';
-import map from 'obliterator/map';
+import {take, map} from '../../src/utils';
 import {deepMerge, sameMembers, addNodesFrom} from '../helpers';
 
 const METHODS = [

--- a/src/graphology/tests/iteration/neighbors.js
+++ b/src/graphology/tests/iteration/neighbors.js
@@ -5,7 +5,7 @@
  * Testing the edges iteration-related methods of the graph.
  */
 import assert from 'assert';
-import take from 'obliterator/take';
+import {take} from '../../src/utils';
 import {deepMerge, addNodesFrom} from '../helpers';
 
 const METHODS = [


### PR DESCRIPTION
Replaces obliterator uses with plain Javascript iterator objects. This lets us remove the obliterator dependency making ESM support more viable. Should be fixing https://github.com/graphology/graphology/issues/382