### PR TITLE
[metrics] new chi-square and g-square edge metric

### DIFF
--- a/docs/standard-library/metrics.md
+++ b/docs/standard-library/metrics.md
@@ -38,6 +38,8 @@ _Edge metrics_
 
 - [Disparity](#disparity)
 - [Simmelian strength](#simmelian-strength)
+- [Chi square](#chi-square)
+- [G square](#g-square)
 
 _Centrality_
 
@@ -339,6 +341,71 @@ const strengths = simmelianStrength(graph);
 // To directly map the result onto edge attributes (`simmelianStrength`):
 simmelianStrength.assign(graph);
 ```
+
+### Chi square
+
+Function computing `chi square` significance tests on each edge.
+The test results are a `number` or `undefined`.
+`undefined` means the test could not be fully computed due to observed weight being less than expected.
+Those cases should be filter out.
+
+To ease filtering the edges based on the results one can use the provided `thresholds`.
+This hashmap gives the minimum value of `chi square` for each level of significance expressed as `p values`.
+
+
+```js
+import chiSquare from 'graphology-metrics/edge/chi-square';
+
+// To compute strength for every edge using weight attribute:
+const chiSquareResults = chiSquare(graph);
+// To compute strength for every edge using weight custom attribute:
+const chiSquareResults = chiSquare(graph, 'cooccurrences');
+// To compute strength for every edge defining weight as an edge function:
+const chiSquareResults = chiSquare(graph, (_, attr) => attr.cooccurrences);
+
+// To directly map the result onto edge attribute `chiSquare`:
+chiSquare.assign(graph);
+
+// filter out unsignificant edges
+graph.filterEdges((_, atts) => atts.chiSquare < chiSquare.thresholds['pValue<0.01']).forEach(e => {graph.dropEdge(e)})
+
+```
+_Arguments_
+
+- **graph** _Graph_: target graph.
+- **getEdgeWeight** <span class="code">?string\|function</span> <span class="default">weight</span>: Name of the edge weight attribute or getter function.
+
+### G square
+
+Function computing `g square` significance tests on each edge.
+The test results are a `number` or `undefined`.
+`undefined` means the test could not be fully computed due to observed weight being less than expected.
+Those cases should be filter out.
+
+To ease filtering the edges based on the results one can use the provided `thresholds`.
+This hashmap gives the minimum value of `g square` for each level of significance expressed as `p values`.
+
+
+```js
+import gSquare from 'graphology-metrics/edge/g-square';
+
+// To compute strength for every edge using weight attribute:
+const gSquareResults = gSquare(graph);
+// To compute strength for every edge using weight custom attribute:
+const gSquareResults = gSquare(graph, 'cooccurrences');
+// To compute strength for every edge defining weight as an edge function:
+const gSquareResults = gSquare(graph, (_, attr) => attr.cooccurrences);
+
+// To directly map the result onto edge attribute `gSquare`:
+gSquare.assign(graph);
+
+// filter out unsignificant edges
+graph.filterEdges((_, atts) => atts.gSquare < gSquare.thresholds['pValue<0.01']).forEach(e => {graph.dropEdge(e)})
+```
+_Arguments_
+
+- **graph** _Graph_: target graph.
+- **getEdgeWeight** <span class="code">?string\|function</span> <span class="default">weight</span>: Name of the edge weight attribute or getter function.
 
 ## Centrality
 

--- a/src/metrics/edge/chi-square-g-square.d.ts
+++ b/src/metrics/edge/chi-square-g-square.d.ts
@@ -1,0 +1,36 @@
+import Graph, {Attributes, EdgeMapper} from 'graphology-types';
+
+export type ChiGSquareOptions<
+  NodeAttributes extends Attributes = Attributes,
+  EdgeAttributes extends Attributes = Attributes
+> = {
+  getEdgeWeight?:
+    | keyof EdgeAttributes
+    | EdgeMapper<number, NodeAttributes, EdgeAttributes>;
+};
+
+export type ChiGSquareMapping = {
+  [edge: string]: {chiSquare: number | undefined; GSquare: number | undefined};
+};
+
+interface IChiGSquare {
+  <
+    NodeAttributes extends Attributes = Attributes,
+    EdgeAttributes extends Attributes = Attributes
+  >(
+    graph: Graph<NodeAttributes, EdgeAttributes>,
+    options?: ChiGSquareOptions<NodeAttributes, EdgeAttributes>
+  ): ChiGSquareMapping;
+
+  assign<
+    NodeAttributes extends Attributes = Attributes,
+    EdgeAttributes extends Attributes = Attributes
+  >(
+    graph: Graph<NodeAttributes, EdgeAttributes>,
+    options?: ChiGSquareOptions<NodeAttributes, EdgeAttributes>
+  ): void;
+}
+
+declare const chiSquareGSquare: IChiGSquare;
+
+export default chiSquareGSquare;

--- a/src/metrics/edge/chi-square-g-square.d.ts
+++ b/src/metrics/edge/chi-square-g-square.d.ts
@@ -1,16 +1,12 @@
 import Graph, {Attributes, EdgeMapper} from 'graphology-types';
 
-export type ChiGSquareOptions<
+export type EdgeWeightOption<
   NodeAttributes extends Attributes = Attributes,
   EdgeAttributes extends Attributes = Attributes
-> = {
-  getEdgeWeight?:
-    | keyof EdgeAttributes
-    | EdgeMapper<number, NodeAttributes, EdgeAttributes>;
-};
+> = keyof EdgeAttributes | EdgeMapper<number, NodeAttributes, EdgeAttributes>;
 
 export type ChiGSquareMapping = {
-  [edge: string]: {chiSquare: number | undefined; GSquare: number | undefined};
+  [edge: string]: number | undefined;
 };
 
 export interface Thresholds {
@@ -29,7 +25,7 @@ interface IChiGSquare {
     EdgeAttributes extends Attributes = Attributes
   >(
     graph: Graph<NodeAttributes, EdgeAttributes>,
-    options?: ChiGSquareOptions<NodeAttributes, EdgeAttributes>
+    weight?: EdgeWeightOption<NodeAttributes, EdgeAttributes>
   ): ChiGSquareMapping;
 
   assign<
@@ -37,12 +33,16 @@ interface IChiGSquare {
     EdgeAttributes extends Attributes = Attributes
   >(
     graph: Graph<NodeAttributes, EdgeAttributes>,
-    options?: ChiGSquareOptions<NodeAttributes, EdgeAttributes>
+    weight?: EdgeWeightOption<NodeAttributes, EdgeAttributes>
   ): void;
 
   thresholds: Thresholds;
 }
 
-declare const chiSquareGSquare: IChiGSquare;
+declare const chiSquare: IChiGSquare;
+declare const gSquare: IChiGSquare;
 
-export default chiSquareGSquare;
+module.exports = {
+  chiSquare: IChiGSquare,
+  gSquare: IChiGSquare
+};

--- a/src/metrics/edge/chi-square-g-square.d.ts
+++ b/src/metrics/edge/chi-square-g-square.d.ts
@@ -13,6 +13,16 @@ export type ChiGSquareMapping = {
   [edge: string]: {chiSquare: number | undefined; GSquare: number | undefined};
 };
 
+export interface Thresholds {
+  'pValue<0.5': number;
+  'pValue<0.1': number;
+  'pValue<0.05': number;
+  'pValue<0.025': number;
+  'pValue<0.01': number;
+  'pValue<0.005': number;
+  'pValue<0.001': number;
+}
+
 interface IChiGSquare {
   <
     NodeAttributes extends Attributes = Attributes,
@@ -29,6 +39,8 @@ interface IChiGSquare {
     graph: Graph<NodeAttributes, EdgeAttributes>,
     options?: ChiGSquareOptions<NodeAttributes, EdgeAttributes>
   ): void;
+
+  thresholds: Thresholds;
 }
 
 declare const chiSquareGSquare: IChiGSquare;

--- a/src/metrics/edge/chi-square-g-square.js
+++ b/src/metrics/edge/chi-square-g-square.js
@@ -1,12 +1,13 @@
 /**
- * CHI-square test
- * ===============
+ * CHI-square G-square tests
+ * =========================
  *
- * Function computing the Simmelian strength, i.e. the number of triangles in
- * which an edge stands, for each edge in a given graph.
+ * Function computing the chi-square and g-square significance measures 
+ * for each edge in a given graph.
+ * Thresholds to filter out edges which fails the significance test are provided but edges are not filtered by default.
+ * 
  */
 var isGraph = require('graphology-utils/is-graph');
-
 
 /**
  * Defaults.
@@ -14,23 +15,25 @@ var isGraph = require('graphology-utils/is-graph');
 var DEFAULT_WEIGHT_ATTRIBUTE = 'weight';
 
 
-//   # compute_chi2_and_g2
-// # test significance using chi2 and g2 metrics
-// # implementation copied from https://github.com/medialab/xan/blob/master/src/cmd/vocab.rs#L924-L1000
-// # gf = global frequency gf (total of token dimension row)
-// # nb_token_in_doc = number of tokens in doc (total of doc dimension coloumn) 
-// # tf = term frequency in document (token x document cell)
-// # token_count = somme de tous les tf (grand total)
+/**
+ * chiSquareGSquareMeasures
+ * implementation copied from https://github.com/medialab/xan/blob/master/src/cmd/vocab.rs#L924-L1000
+ * @param {number} sourceWeightedDegree 
+ * @param {number} targetWeightedDegree 
+ * @param {number} edgeWeight 
+ * @param {number} sumAllEdgesWeights 
+ * @returns Record<edge, {chiSquare:number, gSquare:number}>
+ */
 function chiSquareGSquareMeasures(sourceWeightedDegree, targetWeightedDegree, edgeWeight, sumAllEdgesWeights){
     
     if (sumAllEdgesWeights <= 0)
-        throw new Error('token_count has to be >0')
+        throw new Error('sumAllEdgesWeights has to be >0')
     if (sourceWeightedDegree <= 0)
-        throw new Error('gf has to be >0')
+        throw new Error('sourceWeightedDegree has to be >0')
     if (edgeWeight <= 0)
-        throw new Error('tf has to be >0')
+        throw new Error('edgeWeight has to be >0')
     if (targetWeightedDegree <= 0)
-        throw new Error('nb_tokens_in_doc has to be >0')
+        throw new Error('sumAllEdgesWeights has to be >0')
 
     // This can be 0 if some item is present in all co-occurrences!
     var notGf = sumAllEdgesWeights - sourceWeightedDegree
@@ -87,7 +90,7 @@ function chiSquareGSquareMeasures(sourceWeightedDegree, targetWeightedDegree, ed
 }
 
 /**
- * Asbtract function to perform chiSquare tests measures.
+ * Asbtract function to perform chi-square adn g-square tests measures.
  *
  * @param  {Graph}           graph         - A graphology instance.
  * @param  {string|function} getEdgeWeight - Name of edge weight attribute or getter function.
@@ -142,8 +145,8 @@ function abstractChiSquareGSquare(assign, graph, getEdgeWeight) {
       ? getEdgeWeight(edge, attr, source, target, sa, ta, undirected)
       : attr[getEdgeWeight]
       var measures = chiSquareGSquareMeasures(
-        weightedDegrees[source] || 0,
-        weightedDegrees[target] || 0,
+        weightedDegrees[source],
+        weightedDegrees[target],
         weight, 
         totalWeights)
       edgeChiSquareGSquareMeasures[edge] = measures

--- a/src/metrics/edge/chi-square-g-square.js
+++ b/src/metrics/edge/chi-square-g-square.js
@@ -1,0 +1,173 @@
+/**
+ * CHI-square test
+ * ===============
+ *
+ * Function computing the Simmelian strength, i.e. the number of triangles in
+ * which an edge stands, for each edge in a given graph.
+ */
+var isGraph = require('graphology-utils/is-graph');
+var weightedDegree = require('../node/weighted-degree');
+
+
+/**
+ * Defaults.
+ */
+var DEFAULT_WEIGHT_ATTRIBUTE = 'weight';
+
+
+//   # compute_chi2_and_g2
+// # test significance using chi2 and g2 metrics
+// # implementation copied from https://github.com/medialab/xan/blob/master/src/cmd/vocab.rs#L924-L1000
+// # gf = global frequency gf (total of token dimension row)
+// # nb_token_in_doc = number of tokens in doc (total of doc dimension coloumn) 
+// # tf = term frequency in document (token x document cell)
+// # token_count = somme de tous les tf (grand total)
+function chiSquareGSquareMeasures(sourceWeightedDegree, targetWeightedDegree, edgeWeight, sumAllEdgesWeights){
+    
+    if (sumAllEdgesWeights <= 0)
+        throw new Error('token_count has to be >0')
+    if (sourceWeightedDegree <= 0)
+        throw new Error('gf has to be >0')
+    if (edgeWeight <= 0)
+        throw new Error('tf has to be >0')
+    if (targetWeightedDegree <= 0)
+        throw new Error('nb_tokens_in_doc has to be >0')
+
+    // This can be 0 if some item is present in all co-occurrences!
+    var notGf = sumAllEdgesWeights - sourceWeightedDegree
+    var notNbTokensInDoc = sumAllEdgesWeights - targetWeightedDegree
+
+    
+    var observed11 = edgeWeight
+    var observed12 = sourceWeightedDegree - edgeWeight
+    var  observed21 = targetWeightedDegree - edgeWeight
+    // NOTE: with few co-occurrences, self loops can produce a negative outcome...
+    var observed22 = (sumAllEdgesWeights + edgeWeight) - (sourceWeightedDegree + targetWeightedDegree)
+
+    var expected11 = (sourceWeightedDegree * targetWeightedDegree) / sumAllEdgesWeights // Cannot be 0
+
+    if (edgeWeight < expected11){
+        // under-represented token, measure will be biased, let's ignore the token
+        return {chiSquare: undefined, gSquare: undefined}
+    }
+
+    var expected12 = (sourceWeightedDegree * notNbTokensInDoc)  / sumAllEdgesWeights
+    var expected21 = (targetWeightedDegree * notGf) / sumAllEdgesWeights
+    var expected22 = (notGf * notNbTokensInDoc) / sumAllEdgesWeights
+
+    var chiSquare11 = Math.pow(observed11 - expected11, 2) / expected11
+    var chiSquare12 = Math.pow(observed12 - expected12, 2) / expected12
+    var chiSquare21 = Math.pow(observed21 - expected21, 2) / expected21
+    var chiSquare22 = Math.pow(observed22 - expected22, 2) / expected22
+
+    var gSquare11 = observed11 * Math.log(observed11 / expected11)
+    var gSquare12 = observed12 === 0.0 ? 0.0 : observed12 * Math.log( (observed12 / expected12))
+    var gSquare21 = observed21 === 0.0 ? 0.0 : observed21 * Math.log( (observed21 / expected21))
+
+    // NOTE: in the case when observed_22 is negative, I am not entirely
+    // sure it is mathematically sound to clamp to 0. But since this case
+    // is mostly useless, I will allow it...
+    var gSquare22 = observed22 <= 0.0 ? 0.0 : observed22 * Math.log( (observed22 / expected22))
+
+    var chiSquare = chiSquare11 + chiSquare12 + chiSquare21 + chiSquare22
+    var gSquare = 2.0 * (gSquare11 + gSquare12 + gSquare21 + gSquare22) // 2.0 * is here to adjust g2 in the same scale as chi2
+
+    //  Dealing with degenerate cases that happen when the number
+    //  of co-occurrences is very low, or when some item dominates
+    //  the distribution.
+    if (isNaN(chiSquare))
+      chiSquare = 0.0
+
+    if (chiSquare === Infinity)
+        chiSquare = chiSquare11
+
+    if (gSquare === Infinity)
+        gSquare = gSquare11
+    
+    return {chiSquare:chiSquare, gSquare:gSquare}
+}
+
+/**
+ * Asbtract function to perform chiSquare tests measures.
+ *
+ * @param  {Graph}           graph         - A graphology instance.
+ * @param  {string|function} getEdgeWeight - Name of edge weight attribute or getter function.
+ *
+ */
+function abstractChiSquareGSquare(assign, graph, getEdgeWeight) {
+  if (!isGraph(graph))
+    throw new Error(
+      'graphology-metrics/chi-square: given graph is not a valid graphology instance.'
+    );
+
+  // this metric does not make sens on directed graph. Should we throw if applied on directed graph?
+
+  getEdgeWeight = getEdgeWeight || DEFAULT_WEIGHT_ATTRIBUTE;
+
+  // calculating total weights and weighted degrees
+  var totalWeights = 0
+  var weightedDegrees = {}
+  graph.forEachAssymetricAdjacencyEntry(function (
+      source,
+      target,
+      sa,
+      ta,
+      edge,
+      attr,
+      undirected
+    ) {
+      // sum all weights
+      totalWeights += typeof getEdgeWeight === 'function'
+        ? getEdgeWeight(edge, attr, source, target, sa, ta, undirected)
+        : attr[getEdgeWeight];
+      
+      // compute nodes weighted degrees
+      [source, target].forEach(function (node) {
+        if(!weightedDegrees[node])
+          weightedDegrees[node] = weightedDegree.weightedDegree(graph, node, getEdgeWeight);
+      })
+    })
+
+  var edgeChiSquareGSquareMeasures = {};
+  graph.forEachAssymetricAdjacencyEntry(function (
+      source,
+      target,
+      sa,
+      ta,
+      edge,
+      attr,
+      undirected
+    ) {
+      var weight =  typeof getEdgeWeight === 'function'
+      ? getEdgeWeight(edge, attr, source, target, sa, ta, undirected)
+      : attr[getEdgeWeight]
+      var measures = chiSquareGSquareMeasures(
+        weightedDegrees[source],
+        weightedDegrees[target],
+        weight, 
+        totalWeights)
+      edgeChiSquareGSquareMeasures[edge] = measures
+      
+      if(assign) {
+        graph.setEdgeAttribute(edge, 'chiSquare', measures.chiSquare);
+        graph.setEdgeAttribute(edge, 'gSquare', measures.gSquare);
+      }
+  })
+
+  return edgeChiSquareGSquareMeasures
+}
+
+var chiSquareGSquare = abstractChiSquareGSquare.bind(null, false);
+chiSquareGSquare.assign = abstractChiSquareGSquare.bind(null, true);
+chiSquareGSquare.thresholds =  {
+  'pValue<0.5': 0.45, // lowest significance
+  'pValue<0.1': 2.71, // very low significance
+  'pValue<0.05': 3.84, // low significance
+  'pValue<0.025': 5.02, // good significance
+  'pValue<0.01': 6.63, // high significance
+  'pValue<0.005': 7.88, // very high significance
+  'pValue<0.001': 10.83, // highest significance
+};
+
+
+module.exports = chiSquareGSquare;

--- a/src/metrics/edge/chi-square-g-square.js
+++ b/src/metrics/edge/chi-square-g-square.js
@@ -18,13 +18,14 @@ var DEFAULT_WEIGHT_ATTRIBUTE = 'weight';
 /**
  * chiSquareGSquareMeasures
  * implementation copied from https://github.com/medialab/xan/blob/master/src/cmd/vocab.rs#L924-L1000
+ * @param {chiSquare|gSquare} measure       - either chiSquare or gSquare measure to compute
  * @param {number} sourceWeightedDegree 
  * @param {number} targetWeightedDegree 
  * @param {number} edgeWeight 
  * @param {number} sumAllEdgesWeights 
  * @returns Record<edge, {chiSquare:number, gSquare:number}>
  */
-function chiSquareGSquareMeasures(sourceWeightedDegree, targetWeightedDegree, edgeWeight, sumAllEdgesWeights){
+function _chiSquareGSquareMeasures(measure, sourceWeightedDegree, targetWeightedDegree, edgeWeight, sumAllEdgesWeights){
     
     if (sumAllEdgesWeights <= 0)
         throw new Error('sumAllEdgesWeights has to be >0')
@@ -50,53 +51,55 @@ function chiSquareGSquareMeasures(sourceWeightedDegree, targetWeightedDegree, ed
 
     if (edgeWeight < expected11){
         // under-represented token, measure will be biased, let's ignore the token
-        return {chiSquare: undefined, gSquare: undefined}
+        return undefined;
     }
 
     var expected12 = (sourceWeightedDegree * notNbTokensInDoc)  / sumAllEdgesWeights
     var expected21 = (targetWeightedDegree * notGf) / sumAllEdgesWeights
     var expected22 = (notGf * notNbTokensInDoc) / sumAllEdgesWeights
 
-    var chiSquare11 = Math.pow(observed11 - expected11, 2) / expected11
-    var chiSquare12 = Math.pow(observed12 - expected12, 2) / expected12
-    var chiSquare21 = Math.pow(observed21 - expected21, 2) / expected21
-    var chiSquare22 = Math.pow(observed22 - expected22, 2) / expected22
+    switch(measure){
+      case "gSquare":
+        var gSquare11 = observed11 * Math.log(observed11 / expected11)
+        var gSquare12 = observed12 === 0.0 ? 0.0 : observed12 * Math.log( (observed12 / expected12))
+        var gSquare21 = observed21 === 0.0 ? 0.0 : observed21 * Math.log( (observed21 / expected21))
+        // NOTE: in the case when observed_22 is negative, I am not entirely
+        // sure it is mathematically sound to clamp to 0. But since this case
+        // is mostly useless, I will allow it...
+        var gSquare22 = observed22 <= 0.0 ? 0.0 : observed22 * Math.log( (observed22 / expected22))
+        var gSquare = 2.0 * (gSquare11 + gSquare12 + gSquare21 + gSquare22) // 2.0 * is here to adjust g2 in the same scale as chi2
+        if (gSquare === Infinity)
+          gSquare = gSquare11
+        return gSquare;
+      default:
+      case "chiSquare":
+        var chiSquare11 = Math.pow(observed11 - expected11, 2) / expected11
+        var chiSquare12 = Math.pow(observed12 - expected12, 2) / expected12
+        var chiSquare21 = Math.pow(observed21 - expected21, 2) / expected21
+        var chiSquare22 = Math.pow(observed22 - expected22, 2) / expected22
 
-    var gSquare11 = observed11 * Math.log(observed11 / expected11)
-    var gSquare12 = observed12 === 0.0 ? 0.0 : observed12 * Math.log( (observed12 / expected12))
-    var gSquare21 = observed21 === 0.0 ? 0.0 : observed21 * Math.log( (observed21 / expected21))
+        var chiSquare = chiSquare11 + chiSquare12 + chiSquare21 + chiSquare22
+        //  Dealing with degenerate cases that happen when the number
+        //  of co-occurrences is very low, or when some item dominates
+        //  the distribution.
+        if (isNaN(chiSquare))
+          chiSquare = 0.0
 
-    // NOTE: in the case when observed_22 is negative, I am not entirely
-    // sure it is mathematically sound to clamp to 0. But since this case
-    // is mostly useless, I will allow it...
-    var gSquare22 = observed22 <= 0.0 ? 0.0 : observed22 * Math.log( (observed22 / expected22))
-
-    var chiSquare = chiSquare11 + chiSquare12 + chiSquare21 + chiSquare22
-    var gSquare = 2.0 * (gSquare11 + gSquare12 + gSquare21 + gSquare22) // 2.0 * is here to adjust g2 in the same scale as chi2
-
-    //  Dealing with degenerate cases that happen when the number
-    //  of co-occurrences is very low, or when some item dominates
-    //  the distribution.
-    if (isNaN(chiSquare))
-      chiSquare = 0.0
-
-    if (chiSquare === Infinity)
-        chiSquare = chiSquare11
-
-    if (gSquare === Infinity)
-        gSquare = gSquare11
-    
-    return {chiSquare:chiSquare, gSquare:gSquare}
+        if (chiSquare === Infinity)
+            chiSquare = chiSquare11
+        return chiSquare;
+    };
 }
 
 /**
  * Asbtract function to perform chi-square adn g-square tests measures.
  *
- * @param  {Graph}           graph         - A graphology instance.
- * @param  {string|function} getEdgeWeight - Name of edge weight attribute or getter function.
+ * @param {chiSquare|gSquare} measure       - either chiSquare or gSquare measure to compute
+ * @param  {Graph}            graph         - A graphology instance.
+ * @param  {string|function}  getEdgeWeight - Name of edge weight attribute or getter function.
  *
  */
-function abstractChiSquareGSquare(assign, graph, getEdgeWeight) {
+function abstractChiSquareGSquare(assign, measure, graph, getEdgeWeight) {
   if (!isGraph(graph))
     throw new Error(
       'graphology-metrics/chi-square: given graph is not a valid graphology instance.'
@@ -131,7 +134,7 @@ function abstractChiSquareGSquare(assign, graph, getEdgeWeight) {
       }); 
     });
 
-  var edgeChiSquareGSquareMeasures = {};
+  var edgeMeasures = {};
   graph.forEachAssymetricAdjacencyEntry(function (
       source,
       target,
@@ -144,25 +147,22 @@ function abstractChiSquareGSquare(assign, graph, getEdgeWeight) {
       var weight =  typeof getEdgeWeight === 'function'
       ? getEdgeWeight(edge, attr, source, target, sa, ta, undirected)
       : attr[getEdgeWeight]
-      var measures = chiSquareGSquareMeasures(
+      var result = _chiSquareGSquareMeasures(
+        measure,
         weightedDegrees[source],
         weightedDegrees[target],
         weight, 
         totalWeights)
-      edgeChiSquareGSquareMeasures[edge] = measures
-      
+      edgeMeasures[edge] = result
       if(assign) {
-        graph.setEdgeAttribute(edge, 'chiSquare', measures.chiSquare);
-        graph.setEdgeAttribute(edge, 'gSquare', measures.gSquare);
+        graph.setEdgeAttribute(edge, measure, result);
       }
   })
-
-  return edgeChiSquareGSquareMeasures
+  return edgeMeasures
 }
 
-var chiSquareGSquare = abstractChiSquareGSquare.bind(null, false);
-chiSquareGSquare.assign = abstractChiSquareGSquare.bind(null, true);
-chiSquareGSquare.thresholds =  {
+
+abstractChiSquareGSquare.thresholds =  {
   'pValue<0.5': 0.45, // lowest significance
   'pValue<0.1': 2.71, // very low significance
   'pValue<0.05': 3.84, // low significance
@@ -173,4 +173,4 @@ chiSquareGSquare.thresholds =  {
 };
 
 
-module.exports = chiSquareGSquare;
+module.exports = abstractChiSquareGSquare

--- a/src/metrics/edge/chi-square.js
+++ b/src/metrics/edge/chi-square.js
@@ -1,0 +1,7 @@
+var chiSquareGSquare = require("./chi-square-g-square");
+
+var chiSquare = chiSquareGSquare.bind(null, false, 'chiSquare');
+chiSquare.assign = chiSquareGSquare.bind(null, true, 'chiSquare');
+chiSquare.thresholds = chiSquareGSquare.thresholds;
+
+module.exports = chiSquare;

--- a/src/metrics/edge/g-square.js
+++ b/src/metrics/edge/g-square.js
@@ -1,0 +1,7 @@
+var chiSquareGSquare = require("./chi-square-g-square");
+
+var gSquare = chiSquareGSquare.bind(null, false, 'gSquare');
+gSquare.assign = chiSquareGSquare.bind(null, true, 'gSquare');
+gSquare.thresholds = chiSquareGSquare.thresholds;
+
+module.exports = gSquare;

--- a/src/metrics/edge/index.d.ts
+++ b/src/metrics/edge/index.d.ts
@@ -1,2 +1,3 @@
+export {chiSquare, gSquare} from './chi-square-g-square';
 export {default as disparity} from './disparity';
 export {default as simmelianStrength} from './simmelian-strength';

--- a/src/metrics/edge/index.js
+++ b/src/metrics/edge/index.js
@@ -1,2 +1,4 @@
 exports.disparity = require('./disparity.js');
 exports.simmelianStrength = require('./simmelian-strength.js');
+exports.chiSquare = require('./chi-square.js');
+exports.gSquare = require('./g-square.js');

--- a/src/metrics/test/edge/chi-square-g-square.js
+++ b/src/metrics/test/edge/chi-square-g-square.js
@@ -4,15 +4,19 @@
  */
 var assert = require('assert');
 var Graph = require('graphology');
-var chiSquareGSquare = require('../../edge/chi-square-g-square');
+var chiSquare = require('../../edge/chi-square');
+var gSquare = require('../../edge/g-square');
 
 var UndirectedGraph = Graph.UndirectedGraph;
 
 describe('chiSquareGSquare', function () {
   it('should throw when given an invalid graph.', function () {
     assert.throws(function () {
-        chiSquareGSquare(null);
+      chiSquare(null);
     });
+    assert.throws(function () {
+      gSquare(null);
+  });
   });
 
   it('should return the correct result for cooccurrence network.', function () {
@@ -27,16 +31,26 @@ describe('chiSquareGSquare', function () {
     graph.addEdgeWithKey('catrabbit', 'cat', 'rabbit', {'cooccurrence': 1});
 
 
-    var measures = chiSquareGSquare(graph, 'cooccurrence');
+    var chiSquareResults = chiSquare(graph, 'cooccurrence');
 
-    assert.deepStrictEqual(measures, {
-      'catcat': {chiSquare:undefined, gSquare:undefined},
-      'catdog': {chiSquare:0, gSquare:0},
-      'catrabbit': {chiSquare:0, gSquare:0}
+    assert.deepStrictEqual(chiSquareResults, {
+      'catcat': undefined,
+      'catdog': 0,
+      'catrabbit': 0
+    });
+
+    var gSquareResults = gSquare(graph, 'cooccurrence');
+    assert.deepStrictEqual(gSquareResults, {
+      'catcat': undefined,
+      'catdog': 0,
+      'catrabbit': 0
     });
   });
+
+
   it('should provide relevance thresholds', function(){
-    assert.strictEqual(chiSquareGSquare.thresholds['pValue<0.5'], 0.45)
+    assert.strictEqual(chiSquare.thresholds['pValue<0.5'], 0.45)
+    assert.strictEqual(gSquare.thresholds['pValue<0.5'], 0.45)
   })
 
   it('should return the correct result for occurrence network.', function () {
@@ -55,14 +69,24 @@ describe('chiSquareGSquare', function () {
 
 
 
-    var measures = chiSquareGSquare(graph, 'occurrences');
-    assert.deepStrictEqual(measures, {
-      'doc1Cat': {chiSquare:0.13888888888888884, gSquare:0.13844293808390656},
-      'doc1Dog': {chiSquare:0.8333333333333334, gSquare:1.184939225613002},
-      'doc2Cat': {chiSquare:undefined, gSquare:undefined},
-      'doc2Rabbit': {chiSquare:1.8750000000000002, gSquare:2.231435513142098}
+    var chiSquareResults = chiSquare(graph, 'occurrences');
+    assert.deepStrictEqual(chiSquareResults, {
+      'doc1Cat': 0.13888888888888884, 
+      'doc1Dog': 0.8333333333333334,
+      'doc2Cat': undefined,
+      'doc2Rabbit': 1.8750000000000002
+    });
+
+    var gSquareResults = gSquare(graph, 'occurrences');
+    assert.deepStrictEqual(gSquareResults, {
+      'doc1Cat': 0.13844293808390656,
+      'doc1Dog': 1.184939225613002,
+      'doc2Cat': undefined,
+      'doc2Rabbit': 2.231435513142098
     });
   });
+
+
   it('should return the correct result for occurrence network when using assign.', function () {
     var graph = new UndirectedGraph();
 
@@ -77,11 +101,14 @@ describe('chiSquareGSquare', function () {
     graph.addEdgeWithKey('doc2Cat', 'doc2', 'cat', {'occurrences': 1});
     graph.addEdgeWithKey('doc2Rabbit', 'doc2', 'rabbit', {'occurrences': 1});
 
-    chiSquareGSquare.assign(graph, 'occurrences');
+    chiSquare.assign(graph, 'occurrences');
+    gSquare.assign(graph, 'occurrences');
+    
     var measures = graph.edges().reduce(function (acc,e) {
       acc[e] = graph.getEdgeAttributes(e);
       return acc;
     }, {})
+    
     assert.deepStrictEqual(measures, {
       'doc1Cat': {occurrences: 2, chiSquare:0.13888888888888884, gSquare:0.13844293808390656},
       'doc1Dog': {occurrences: 1, chiSquare:0.8333333333333334, gSquare:1.184939225613002},

--- a/src/metrics/test/edge/chi-square-g-square.js
+++ b/src/metrics/test/edge/chi-square-g-square.js
@@ -1,0 +1,92 @@
+/**
+ * Graphology Edge Chi Square/G Square Unit Tests
+ * =====================================
+ */
+var assert = require('assert');
+var Graph = require('graphology');
+var chiSquareGSquare = require('../../edge/chi-square-g-square');
+
+var UndirectedGraph = Graph.UndirectedGraph;
+
+describe('chiSquareGSquare', function () {
+  it('should throw when given an invalid graph.', function () {
+    assert.throws(function () {
+        chiSquareGSquare(null);
+    });
+  });
+
+  it('should return the correct result for cooccurrence network.', function () {
+    var graph = new UndirectedGraph();
+
+    graph.addNode('cat');
+    graph.addNode('dog');
+    graph.addNode('rabbit');
+
+    graph.addEdgeWithKey('catcat','cat', 'cat', {'cooccurrence': 1});
+    graph.addEdgeWithKey('catdog', 'cat', 'dog', {'cooccurrence': 1});
+    graph.addEdgeWithKey('catrabbit', 'cat', 'rabbit', {'cooccurrence': 1});
+
+
+    var measures = chiSquareGSquare(graph, 'cooccurrence');
+
+    assert.deepStrictEqual(measures, {
+      'catcat': {chiSquare:undefined, gSquare:undefined},
+      'catdog': {chiSquare:0, gSquare:0},
+      'catrabbit': {chiSquare:0, gSquare:0}
+    });
+  });
+  it('should provide relevance thresholds', function(){
+    assert.strictEqual(chiSquareGSquare.thresholds['pValue<0.5'], 0.45)
+  })
+
+  it('should return the correct result for occurrence network.', function () {
+    var graph = new UndirectedGraph();
+
+    graph.addNode('doc1');
+    graph.addNode('doc2');
+    graph.addNode('cat');
+    graph.addNode('dog');
+    graph.addNode('rabbit');
+
+    graph.addEdgeWithKey('doc1Cat','doc1', 'cat', {'occurrences': 2});
+    graph.addEdgeWithKey('doc1Dog', 'doc1', 'dog', {'occurrences': 1});
+    graph.addEdgeWithKey('doc2Cat', 'doc2', 'cat', {'occurrences': 1});
+    graph.addEdgeWithKey('doc2Rabbit', 'doc2', 'rabbit', {'occurrences': 1});
+
+
+
+    var measures = chiSquareGSquare(graph, 'occurrences');
+    assert.deepStrictEqual(measures, {
+      'doc1Cat': {chiSquare:0.13888888888888884, gSquare:0.13844293808390656},
+      'doc1Dog': {chiSquare:0.8333333333333334, gSquare:1.184939225613002},
+      'doc2Cat': {chiSquare:undefined, gSquare:undefined},
+      'doc2Rabbit': {chiSquare:1.8750000000000002, gSquare:2.231435513142098}
+    });
+  });
+  it('should return the correct result for occurrence network when using assign.', function () {
+    var graph = new UndirectedGraph();
+
+    graph.addNode('doc1');
+    graph.addNode('doc2');
+    graph.addNode('cat');
+    graph.addNode('dog');
+    graph.addNode('rabbit');
+
+    graph.addEdgeWithKey('doc1Cat','doc1', 'cat', {'occurrences': 2});
+    graph.addEdgeWithKey('doc1Dog', 'doc1', 'dog', {'occurrences': 1});
+    graph.addEdgeWithKey('doc2Cat', 'doc2', 'cat', {'occurrences': 1});
+    graph.addEdgeWithKey('doc2Rabbit', 'doc2', 'rabbit', {'occurrences': 1});
+
+    chiSquareGSquare.assign(graph, 'occurrences');
+    var measures = graph.edges().reduce(function (acc,e) {
+      acc[e] = graph.getEdgeAttributes(e);
+      return acc;
+    }, {})
+    assert.deepStrictEqual(measures, {
+      'doc1Cat': {occurrences: 2, chiSquare:0.13888888888888884, gSquare:0.13844293808390656},
+      'doc1Dog': {occurrences: 1, chiSquare:0.8333333333333334, gSquare:1.184939225613002},
+      'doc2Cat': {occurrences: 1, chiSquare:undefined, gSquare:undefined},
+      'doc2Rabbit': {occurrences: 1, chiSquare:1.8750000000000002, gSquare:2.231435513142098}
+    });
+  });
+});


### PR DESCRIPTION
Add a edge metric to compute chi square and g square significance tests.
Chi Square and G square are redundant. One should use only one of the tow. 
Computing them both does not require much more computation power but we could prefer to add a param to chose between the two.
The metrics also provide the standard thresholds to use for filter edges based on the results depending on desired p value precision.