### PR TITLE
Fix default values for canvas and npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@yomguithereal/eslint-config": "^4.4.0",
         "@yomguithereal/prettier-config": "^1.2.0",
         "chai": "^4.3.6",
-        "chai-roughly": "^1.0.0",
+        "chai-roughly-v2": "^2.0.13",
         "eslint": "^8.12.0",
         "eslint-config-prettier": "^8.5.0",
         "lerna": "^4.0.0",
@@ -4873,33 +4873,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/chai-roughly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chai-roughly/-/chai-roughly-1.0.0.tgz",
-      "integrity": "sha512-lCV6EsBpMVFKhPXUrO/Ps4ZZW+esi16lB3kAsKFC1kc0qgTdOSd9qlDgOvG0e07wYysTT+FfHbStvH5oF11xRQ==",
+    "node_modules/chai-roughly-v2": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/chai-roughly-v2/-/chai-roughly-v2-2.0.13.tgz",
+      "integrity": "sha512-caykrHy3IdCsMAnP+imBQCo7kd3qNd0rOHebK958Uw+jHQAbzUWxltO2eBLoMFeBVG+sM/eIYBG4VArcXBeoZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "deep-eql": "git+https://github.com/Turbo87/deep-eql.git#9bad4db"
-      }
-    },
-    "node_modules/chai-roughly/node_modules/deep-eql": {
-      "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/Turbo87/deep-eql.git#9bad4db6794aa0ce74a1118ad6e38df5c70992f3",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/chai-roughly/node_modules/type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
+        "deep-eql": "^4.1.1"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@yomguithereal/eslint-config": "^4.4.0",
     "@yomguithereal/prettier-config": "^1.2.0",
     "chai": "^4.3.6",
-    "chai-roughly": "^1.0.0",
+    "chai-roughly-v2": "^2.0.13",
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "lerna": "^4.0.0",

--- a/src/canvas/defaults.js
+++ b/src/canvas/defaults.js
@@ -20,19 +20,20 @@ exports.DEFAULTS = DEFAULTS;
 exports.refineSettings = function refineSettings(settings) {
   settings = settings || {};
 
-  var dimensions = {
-    width: settings.width,
-    height: settings.height
-  };
+  var widthWithFallback = settings.width;
+  var heightWithFallback = settings.height;
 
-  if (dimensions.width && !dimensions.height)
-    dimensions.height = dimensions.width;
+  if (widthWithFallback && !heightWithFallback)
+    heightWithFallback = widthWithFallback;
 
-  if (dimensions.height && !dimensions.width)
-    dimensions.width = dimensions.height;
+  if (heightWithFallback && !widthWithFallback)
+    widthWithFallback = heightWithFallback;
 
-  settings = resolveDefaults(settings, dimensions);
-  settings = resolveDefaults(settings, DEFAULTS);
+  settings = resolveDefaults({
+    ...settings,
+    width: widthWithFallback,
+    height: heightWithFallback,
+  }, DEFAULTS);
 
   if (!settings.width && !settings.height)
     throw new Error(

--- a/src/canvas/test/index.js
+++ b/src/canvas/test/index.js
@@ -4,11 +4,55 @@
  */
 var assert = require('assert');
 var DEFAULT_NODE_REDUCER = require('../defaults.js').DEFAULT_NODE_REDUCER;
+var { refineSettings, DEFAULTS } = require('../defaults.js');
 
 describe('graphology-canvas', function () {
+
   it('should throw if some node has no position.', function () {
     assert.throws(function () {
-      DEFAULT_NODE_REDUCER({}, 'John', {color: 'green'});
+      DEFAULT_NODE_REDUCER({}, 'John', { color: 'green' });
     }, /position/);
   });
+
+  describe('refineSettings', function () {
+
+    it('works with nullish structures', function () {
+      const res2 = refineSettings();
+      const res1 = refineSettings(null);
+      const res3 = refineSettings({});
+      assert.deepEqual(res1, DEFAULTS);
+      assert.deepEqual(res2, DEFAULTS);
+      assert.deepEqual(res3, DEFAULTS);
+    });
+
+    it('squarifies when only width or height provided', function () {
+      const resW = refineSettings({ width: 100 });
+      assert.deepEqual(resW, {
+        ...DEFAULTS,
+        width: 100,
+        height: 100
+      });
+      const resH = refineSettings({ height: 200 });
+      assert.deepEqual(resH, {
+        ...DEFAULTS,
+        width: 200,
+        height: 200
+      });
+    });
+
+    it('works with reducers', function () {
+      const TEST_REDUCER = () => { };
+      const res = refineSettings({
+        nodes: { reducer: TEST_REDUCER },
+        edges: { reducer: TEST_REDUCER },
+      });
+      assert.deepEqual(res, {
+        ...DEFAULTS,
+        nodes: { reducer: TEST_REDUCER, defaultColor: DEFAULTS.nodes.defaultColor },
+        edges: { reducer: TEST_REDUCER, defaultColor: DEFAULTS.edges.defaultColor },
+      });
+    });
+
+  });
+
 });

--- a/src/minivan/test/index.js
+++ b/src/minivan/test/index.js
@@ -6,7 +6,7 @@
 require('util').inspect.defaultOptions.depth = null;
 
 var chai = require('chai');
-chai.use(require('chai-roughly'));
+chai.use(require('chai-roughly-v2'));
 var assert = chai.assert;
 var expect = chai.expect;
 var deepclone = require('lodash/cloneDeep');


### PR DESCRIPTION
Fixes:
- The default values was always overrriding the provided props (eg. reducers) to null and made reducers unusable.
- Chai-roughly had a dependency which was deleted and therefore a fresh npm install was failing (https://github.com/Turbo87/chai-roughly/issues/13)